### PR TITLE
(motionblur) Everything ported to slang.

### DIFF
--- a/motionblur/braid-rewind.slangp
+++ b/motionblur/braid-rewind.slangp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/braid-rewind.slang
+filter_linear0 = false
+scale_type_0 = source

--- a/motionblur/feedback.slangp
+++ b/motionblur/feedback.slangp
@@ -1,0 +1,7 @@
+shaders = 1
+
+shader0 = shaders/feedback.slang
+scale_type0 = source
+scale0 = 1.0
+
+filter_linear0 = false

--- a/motionblur/motionblur-blue.slangp
+++ b/motionblur/motionblur-blue.slangp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/motionblur-blue.slang
+filter_linear0 = false
+scale_type_0 = source

--- a/motionblur/motionblur-color.slangp
+++ b/motionblur/motionblur-color.slangp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/motionblur-color.slang
+filter_linear0 = false
+scale_type_0 = source

--- a/motionblur/motionblur-simple.slangp
+++ b/motionblur/motionblur-simple.slangp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/motionblur-simple.slang
+filter_linear0 = false
+scale_type_0 = source

--- a/motionblur/shaders/braid-rewind.slang
+++ b/motionblur/shaders/braid-rewind.slang
@@ -1,0 +1,66 @@
+#version 450
+/*
+    Braid Rewind
+    Authors: hunterk, cgwg
+ 
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the Free
+    Software Foundation; either version 2 of the License, or (at your option)
+    any later version.
+*/
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+    vec4 OutputSize;
+    vec4 OriginalSize;
+    vec4 SourceSize;
+    float FrameDirection
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D OriginalHistory1;
+layout(set = 0, binding = 4) uniform sampler2D OriginalHistory2;
+layout(set = 0, binding = 5) uniform sampler2D OriginalHistory3;
+layout(set = 0, binding = 6) uniform sampler2D OriginalHistory4;
+layout(set = 0, binding = 7) uniform sampler2D OriginalHistory5;
+layout(set = 0, binding = 8) uniform sampler2D OriginalHistory6;
+layout(set = 0, binding = 9) uniform sampler2D OriginalHistory7;
+
+void main()
+{
+    vec4 current = texture(Source, vTexCoord);
+
+    vec4 color = 
+        texture(OriginalHistory7, vTexCoord) +
+        texture(OriginalHistory6, vTexCoord) +
+        texture(OriginalHistory5, vTexCoord) +
+        texture(OriginalHistory4, vTexCoord) +
+        texture(OriginalHistory3, vTexCoord) +
+        texture(OriginalHistory2, vTexCoord) +
+        texture(OriginalHistory1, vTexCoord) +
+        current;
+
+    vec4 sepia = vec4(1.0, 0.8, 0.6, 1.0); 
+
+    if (global.FrameDirection < 0.0)
+    {
+        current = ((current + (color * 0.142857142857143)) * 0.5) * sepia;
+    }
+
+    FragColor = current;
+}

--- a/motionblur/shaders/feedback.slang
+++ b/motionblur/shaders/feedback.slang
@@ -1,0 +1,42 @@
+#version 450
+
+layout(push_constant) uniform Push
+{
+    float mixfactor;
+} param;
+
+#pragma parameter mixfactor "Motionblur Fadeout" 0.75 0.0 1.0 0.01
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+    vec4 OutputSize;
+    vec4 OriginalSize;
+    vec4 SourceSize;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D PassFeedback0;
+
+void main()
+{
+    vec4 current = pow(texture(Source,        vTexCoord), vec4(2.2));
+    vec4 fdback  = pow(texture(PassFeedback0, vTexCoord), vec4(2.2));
+    vec4 mixed   = (1.0 - param.mixfactor) * current + param.mixfactor * fdback;
+    
+    FragColor = pow(mixed, vec4(1.0 / 2.2));
+}

--- a/motionblur/shaders/motionblur-blue.slang
+++ b/motionblur/shaders/motionblur-blue.slang
@@ -1,0 +1,52 @@
+#version 450
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+    vec4 OutputSize;
+    vec4 OriginalSize;
+    vec4 SourceSize;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D OriginalHistory1;
+layout(set = 0, binding = 4) uniform sampler2D OriginalHistory2;
+layout(set = 0, binding = 5) uniform sampler2D OriginalHistory3;
+layout(set = 0, binding = 6) uniform sampler2D OriginalHistory4;
+layout(set = 0, binding = 7) uniform sampler2D OriginalHistory5;
+layout(set = 0, binding = 8) uniform sampler2D OriginalHistory6;
+layout(set = 0, binding = 9) uniform sampler2D OriginalHistory7;
+
+void main()
+{
+    float blue_result = 
+        texture(OriginalHistory1, vTexCoord).b +
+        texture(OriginalHistory2, vTexCoord).b +
+        texture(OriginalHistory3, vTexCoord).b +
+        texture(OriginalHistory4, vTexCoord).b +
+        texture(OriginalHistory5, vTexCoord).b +
+        texture(OriginalHistory6, vTexCoord).b +
+        texture(OriginalHistory7, vTexCoord).b -
+        texture(Source,           vTexCoord).b * 7.0;
+
+    blue_result = clamp(blue_result, 0.0, 1.0);
+    
+    FragColor = clamp(
+        texture(Source, vTexCoord) + 0.4 * vec4(0.0, 0.0, blue_result, 1.0),
+        0.0, 1.0
+    );
+}

--- a/motionblur/shaders/motionblur-color.slang
+++ b/motionblur/shaders/motionblur-color.slang
@@ -1,0 +1,78 @@
+#version 450
+/* Derived from https://github.com/libretro/slang-shaders/blob/master/motionblur/motionblur-blue.slang
+   To increase the effect, uncomment more OriginalHistory# lines in each color channel
+*/
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+    vec4 OutputSize;
+    vec4 OriginalSize;
+    vec4 SourceSize;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D OriginalHistory1;
+layout(set = 0, binding = 4) uniform sampler2D OriginalHistory2;
+layout(set = 0, binding = 5) uniform sampler2D OriginalHistory3;
+layout(set = 0, binding = 6) uniform sampler2D OriginalHistory4;
+layout(set = 0, binding = 7) uniform sampler2D OriginalHistory5;
+layout(set = 0, binding = 8) uniform sampler2D OriginalHistory6;
+layout(set = 0, binding = 9) uniform sampler2D OriginalHistory7;
+
+void main()
+{
+    float red_result = 
+        texture(OriginalHistory1, vTexCoord).r +
+        texture(OriginalHistory2, vTexCoord).r /*+
+        texture(OriginalHistory3, vTexCoord).r +
+        texture(OriginalHistory4, vTexCoord).r +
+        texture(OriginalHistory5, vTexCoord).r +
+        texture(OriginalHistory6, vTexCoord).r +
+        texture(OriginalHistory7, vTexCoord).r*/;
+
+    float green_result = 
+        texture(OriginalHistory1, vTexCoord).g +
+        texture(OriginalHistory2, vTexCoord).g /*+
+        texture(OriginalHistory3, vTexCoord).g +
+        texture(OriginalHistory4, vTexCoord).g +
+        texture(OriginalHistory5, vTexCoord).g +
+        texture(OriginalHistory6, vTexCoord).g +
+        texture(OriginalHistory7, vTexCoord).g*/;
+
+    float blue_result = 
+        texture(OriginalHistory1, vTexCoord).b +
+        texture(OriginalHistory2, vTexCoord).b /*+
+        texture(OriginalHistory3, vTexCoord).b +
+        texture(OriginalHistory4, vTexCoord).b +
+        texture(OriginalHistory5, vTexCoord).b +
+        texture(OriginalHistory6, vTexCoord).b +
+        texture(OriginalHistory7, vTexCoord).b*/;
+
+
+    blue_result = clamp(blue_result, 0.0, 1.0);
+    
+    FragColor = 
+        clamp(texture(Source, vTexCoord) + 0.4 * 
+            vec4(clamp(red_result   - 7.0 * texture(Source, vTexCoord).r, 0.0, 1.0),
+                 clamp(green_result - 7.0 * texture(Source, vTexCoord).g, 0.0, 1.0),
+                 clamp(blue_result  - 7.0 * texture(Source, vTexCoord).b, 0.0, 1.0),
+                 1.0),
+            0.0, 
+            1.0
+        );
+}

--- a/motionblur/shaders/motionblur-simple.slang
+++ b/motionblur/shaders/motionblur-simple.slang
@@ -1,0 +1,55 @@
+#version 450
+/*
+    Motion Blur
+    Authors: hunterk, cgwg
+ 
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the Free
+    Software Foundation; either version 2 of the License, or (at your option)
+    any later version.
+*/
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+    vec4 OutputSize;
+    vec4 OriginalSize;
+    vec4 SourceSize;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D OriginalHistory1;
+layout(set = 0, binding = 4) uniform sampler2D OriginalHistory2;
+layout(set = 0, binding = 5) uniform sampler2D OriginalHistory3;
+layout(set = 0, binding = 6) uniform sampler2D OriginalHistory4;
+layout(set = 0, binding = 7) uniform sampler2D OriginalHistory5;
+layout(set = 0, binding = 8) uniform sampler2D OriginalHistory6;
+layout(set = 0, binding = 9) uniform sampler2D OriginalHistory7;
+
+void main()
+{
+    vec4 color = texture(OriginalHistory7, vTexCoord);
+    color = (color + texture(OriginalHistory6, vTexCoord)) * 0.5;
+    color = (color + texture(OriginalHistory5, vTexCoord)) * 0.5;
+    color = (color + texture(OriginalHistory4, vTexCoord)) * 0.5;
+    color = (color + texture(OriginalHistory3, vTexCoord)) * 0.5;
+    color = (color + texture(OriginalHistory2, vTexCoord)) * 0.5;
+    color = (color + texture(OriginalHistory1, vTexCoord)) * 0.5;
+    color = (color + texture(Source,           vTexCoord)) * 0.5;
+
+    FragColor = color;
+}


### PR DESCRIPTION
The braid-rewind shader won't compile because it relies on
'global.FrameDirection', meant to be the counterpart to Cg's
IN.frame_direction.