### PR TITLE
reworked gbc border shaders

### DIFF
--- a/handheld/console-border/gbc-2x.slangp
+++ b/handheld/console-border/gbc-2x.slangp
@@ -1,0 +1,22 @@
+shaders = "2"
+
+shader0 = "../shaders/lcd-cgwg/lcd-grid.slang"
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+scale_type_x0 = "source"
+scale_x0 = "2.000000"
+scale_type_y0 = "source"
+scale_y0 = "2.000000"
+
+shader1 = shader-files/gb-pass-5.slang
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+
+textures = "BORDER"
+BORDER = "resources/color-border-square-4x.png"
+BORDER_linear = "true"
+BORDER_wrap_mode = "clamp_to_border"
+BORDER_mipmap = "false"

--- a/handheld/console-border/gbc-3x.slangp
+++ b/handheld/console-border/gbc-3x.slangp
@@ -1,0 +1,22 @@
+shaders = "2"
+
+shader0 = "../shaders/lcd-cgwg/lcd-grid.slang"
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+scale_type_x0 = "source"
+scale_x0 = "3.000000"
+scale_type_y0 = "source"
+scale_y0 = "3.000000"
+
+shader1 = shader-files/gb-pass-5.slang
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+
+textures = "BORDER"
+BORDER = "resources/color-border-square-4x.png"
+BORDER_linear = "true"
+BORDER_wrap_mode = "clamp_to_border"
+BORDER_mipmap = "false"

--- a/handheld/console-border/gbc-4x.slangp
+++ b/handheld/console-border/gbc-4x.slangp
@@ -1,0 +1,23 @@
+shaders = "2"
+
+shader0 = "../shaders/lcd-cgwg/lcd-grid.slang"
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+scale_type_x0 = "source"
+scale_x0 = "4.000000"
+scale_type_y0 = "source"
+scale_y0 = "4.000000"
+
+shader1 = shader-files/gb-pass-5.slang
+
+parameters = "SCALE;OUT_X;OUT_Y"
+video_scale = "4.0"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+
+textures = "BORDER"
+BORDER = "resources/color-border-square-4x.png"
+BORDER_linear = "true"
+BORDER_wrap_mode = "clamp_to_border"
+BORDER_mipmap = "false"

--- a/handheld/console-border/gbc-5x.slangp
+++ b/handheld/console-border/gbc-5x.slangp
@@ -1,0 +1,22 @@
+shaders = "2"
+
+shader0 = "../shaders/lcd-cgwg/lcd-grid.slang"
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+scale_type_x0 = "source"
+scale_x0 = "6.000000"
+scale_type_y0 = "source"
+scale_y0 = "6.000000"
+
+shader1 = shader-files/gb-pass-5.slang
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+
+textures = "BORDER"
+BORDER = "resources/color-border-square-4x.png"
+BORDER_linear = "true"
+BORDER_wrap_mode = "clamp_to_border"
+BORDER_mipmap = "false"

--- a/handheld/console-border/gbc-6x.slangp
+++ b/handheld/console-border/gbc-6x.slangp
@@ -1,0 +1,22 @@
+shaders = "2"
+
+shader0 = "../shaders/lcd-cgwg/lcd-grid.slang"
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+scale_type_x0 = "source"
+scale_x0 = "6.000000"
+scale_type_y0 = "source"
+scale_y0 = "6.000000"
+
+shader1 = shader-files/gb-pass-5.slang
+
+parameters = "SCALE;OUT_X;OUT_Y;"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+
+textures = "BORDER"
+BORDER = "resources/color-border-square-4x.png"
+BORDER_linear = "true"
+BORDER_wrap_mode = "clamp_to_border"
+BORDER_mipmap = "false"


### PR DESCRIPTION
gbc border shaders which use gba-pass5.slang instead of border.slang 
Function correctly on 1080p screen.