### PR TITLE
(xSaL) Translated all files from Cg to slang

### DIFF
--- a/xsal/2xsal-level2 - CRT.slangp
+++ b/xsal/2xsal-level2 - CRT.slangp
@@ -1,0 +1,12 @@
+shaders = 2
+
+shader0 = shaders/2xsal-level2.slang
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = ../crt/shaders/dotmask.slang
+filter_linear1 = true
+scale_type1 = viewport
+scale1 = 1.0

--- a/xsal/2xsal-level2.slangp
+++ b/xsal/2xsal-level2.slangp
@@ -1,0 +1,11 @@
+shaders = 2
+
+shader0 = shaders/2xsal-level2.slang
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = ../stock.slang
+filter_linear1 = true
+scale_type_1 = source

--- a/xsal/2xsal.slangp
+++ b/xsal/2xsal.slangp
@@ -1,0 +1,11 @@
+shaders = 2
+
+shader0 = shaders/2xsal.slang
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = ../stock.slang
+filter_linear1 = true
+scale_type_1 = source

--- a/xsal/4xsal-level2 - CRT.slangp
+++ b/xsal/4xsal-level2 - CRT.slangp
@@ -1,0 +1,18 @@
+shaders = 3
+
+shader0 = shaders/2xsal-level2.slang
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = shaders/2xsal.slang
+filter_linear1 = false
+scale_type1 = source
+scale_x1 = 2.0
+scale_y1 = 2.0
+
+shader2 = ../crt/shaders/dotmask.slang
+filter_linear2 = true
+scale_type2 = viewport
+scale2 = 1.0

--- a/xsal/4xsal-level2 - DDT.slangp
+++ b/xsal/4xsal-level2 - DDT.slangp
@@ -1,0 +1,13 @@
+shaders = 2
+
+shader0 = shaders/2xsal-level2.slang
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = ../ddt/shaders/ddt-extended.slang
+filter_linear1 = false
+scale_type1 = viewport
+scale1 = 1.0 
+

--- a/xsal/4xsal-level2.slangp
+++ b/xsal/4xsal-level2.slangp
@@ -1,0 +1,17 @@
+shaders = 3
+
+shader0 = shaders/2xsal-level2.slang
+filter_linear0 = false
+scale_type0 = source
+scale_x0 = 2.0
+scale_y0 = 2.0
+
+shader1 = shaders/2xsal.slang
+filter_linear1 = false
+scale_type1 = source
+scale_x1 = 2.0
+scale_y1 = 2.0
+
+shader2 = ../stock.slang
+filter_linear2 = true
+scale_type2 = source 

--- a/xsal/shaders/2xsal-level2.slang
+++ b/xsal/shaders/2xsal-level2.slang
@@ -1,0 +1,95 @@
+#version 450
+
+/*
+    Copyright (C) 2016 guest(r) - guest.r@gmail.com
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+layout(push_constant) uniform Push
+{
+    vec4 OutputSize;
+    vec4 OriginalSize;
+    vec4 SourceSize;
+} params;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in  vec4 Position;
+layout(location = 1) in  vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+/* Default Vertex shader */
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in  vec2 vTexCoord;
+layout(location = 1) in  vec2 FragCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+void main()
+{
+    float dx = 0.25 * params.SourceSize.z;
+    float dy = 0.25 * params.SourceSize.w;
+    vec3  dt = vec3(1.0, 1.0, 1.0);
+
+    vec4 yx = vec4(  dx,   dy,      -dx,   -dy);
+    vec4 xh = vec4(3*dx,   dy,    -3*dx,   -dy);
+    vec4 yv = vec4(  dx, 3*dy,      -dx, -3*dy);
+
+    vec3 c11 = texture(Source, vTexCoord        ).xyz;  
+    vec3 s00 = texture(Source, vTexCoord + yx.zw).xyz;
+    vec3 s20 = texture(Source, vTexCoord + yx.xw).xyz;
+    vec3 s22 = texture(Source, vTexCoord + yx.xy).xyz;
+    vec3 s02 = texture(Source, vTexCoord + yx.zy).xyz;
+    vec3 h00 = texture(Source, vTexCoord + xh.zw).xyz;
+    vec3 h20 = texture(Source, vTexCoord + xh.xw).xyz;
+    vec3 h22 = texture(Source, vTexCoord + xh.xy).xyz;
+    vec3 h02 = texture(Source, vTexCoord + xh.zy).xyz;
+    vec3 v00 = texture(Source, vTexCoord + yv.zw).xyz;
+    vec3 v20 = texture(Source, vTexCoord + yv.xw).xyz;
+    vec3 v22 = texture(Source, vTexCoord + yv.xy).xyz;
+    vec3 v02 = texture(Source, vTexCoord + yv.zy).xyz;
+
+    float m1 = 1.0/(dot(abs(s00 - s22), dt) + 0.00001);
+    float m2 = 1.0/(dot(abs(s02 - s20), dt) + 0.00001);   
+    float h1 = 1.0/(dot(abs(s00 - h22), dt) + 0.00001);
+    float h2 = 1.0/(dot(abs(s02 - h20), dt) + 0.00001);
+    float h3 = 1.0/(dot(abs(h00 - s22), dt) + 0.00001);
+    float h4 = 1.0/(dot(abs(h02 - s20), dt) + 0.00001);
+    float v1 = 1.0/(dot(abs(s00 - v22), dt) + 0.00001);
+    float v2 = 1.0/(dot(abs(s02 - v20), dt) + 0.00001);
+    float v3 = 1.0/(dot(abs(v00 - s22), dt) + 0.00001);
+    float v4 = 1.0/(dot(abs(v02 - s20), dt) + 0.00001);
+
+    vec3 t1 = 0.5*(m1*(s00 + s22) + m2*(s02 + s20))/(m1 + m2);
+    vec3 t2 = 0.5*(h1*(s00 + h22) + h2*(s02 + h20) + h3*(h00+s22) + h4*(h02 + s20))/(h1 + h2 + h3 + h4);
+    vec3 t3 = 0.5*(v1*(s00 + v22) + v2*(s02 + v20) + v3*(v00+s22) + v4*(v02 + s20))/(v1 + v2 + v3 + v4);
+
+    float k1 = 1.0/(dot(abs(t1 - c11),dt) + 0.00001);
+    float k2 = 1.0/(dot(abs(t2 - c11),dt) + 0.00001);
+    float k3 = 1.0/(dot(abs(t3 - c11),dt) + 0.00001);   
+
+    FragColor = vec4((k1*t1 + k2*t2 + k3*t3)/(k1 + k2 + k3), 1.0);
+}

--- a/xsal/shaders/2xsal.slang
+++ b/xsal/shaders/2xsal.slang
@@ -1,0 +1,79 @@
+#version 450
+
+/*
+    Copyright (C) 2007 guest(r) - guest.r@gmail.com
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+
+layout(push_constant) uniform Push
+{
+    vec4 OutputSize;
+    vec4 OriginalSize;
+    vec4 SourceSize;
+} params;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in  vec4 Position;
+layout(location = 1) in  vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+/* Default Vertex shader */
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in  vec2 vTexCoord;
+layout(location = 1) in  vec2 FragCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+struct deltas
+{
+   vec2 UL, UR, DL, DR;
+};
+
+void main()
+{
+    vec2  texsize = params.SourceSize.xy;
+    float dx      = pow(texsize.x, -1.0) * 0.25;
+    float dy      = pow(texsize.y, -1.0) * 0.25;
+    vec3  dt      = vec3(1.0, 1.0, 1.0);
+
+    deltas VAR = { 
+        vTexCoord + vec2(-dx, -dy),
+        vTexCoord + vec2( dx, -dy),
+        vTexCoord + vec2(-dx,  dy),
+        vTexCoord + vec2( dx,  dy)
+    };
+
+    vec3 c00 = texture(Source, VAR.UL).xyz;
+    vec3 c20 = texture(Source, VAR.UR).xyz;
+    vec3 c02 = texture(Source, VAR.DL).xyz;
+    vec3 c22 = texture(Source, VAR.DR).xyz;
+
+    float m1 = dot(abs(c00 - c22), dt) + 0.001;
+    float m2 = dot(abs(c02 - c20), dt) + 0.001;
+
+    FragColor = vec4((m1*(c02 + c20) + m2*(c22 + c00)) / (2.0*(m1 + m2)), 1.0);
+}


### PR DESCRIPTION
Had to remove what seems to be the AMD rounding fix off of the vertex shaders in order to better match the Cg versions.

The only optimizations done were using the precalculated Z and W coordinates from SourceSize, instead of X and Y (turns a couple of divisions into multiplications).