### PR TITLE
(nes-color-decoder) Use correct level when color is 0xE and 0xF

### DIFF
--- a/misc/nes-color-decoder-alt.slang
+++ b/misc/nes-color-decoder-alt.slang
@@ -58,6 +58,9 @@ vec3 MakeRGBColor(int emphasis, int level, int color)
    float g = 0.0;
    float b = 0.0;
 
+   // Color 0xE and 0xF are black
+   level = (color < 14) ? level : 1;
+
    // Voltage levels, relative to synch voltage
    float black = 0.518;
    float white = 1.962;

--- a/misc/nes-color-decoder-sony.slang
+++ b/misc/nes-color-decoder-sony.slang
@@ -58,6 +58,9 @@ vec3 MakeRGBColor(int emphasis, int level, int color)
    float g = 0.0;
    float b = 0.0;
 
+   // Color 0xE and 0xF are black
+   level = (color < 14) ? level : 1;
+
    // Voltage levels, relative to synch voltage
    float black = 0.518;
    float white = 1.962;

--- a/misc/nes-color-decoder.slang
+++ b/misc/nes-color-decoder.slang
@@ -58,6 +58,9 @@ vec3 MakeRGBColor(int emphasis, int level, int color)
    float g = 0.0;
    float b = 0.0;
 
+   // Color 0xE and 0xF are black
+   level = (color < 14) ? level : 1;
+
    // Voltage levels, relative to synch voltage
    float black = 0.518;
    float white = 1.962;


### PR DESCRIPTION
Fixes a glitch that occurred when Castlevania III password screen fades to black.