### PR TITLE
[handheld] simpletex_lcd: Update GBC colour correction 

### DIFF
--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.slang
@@ -8,7 +8,7 @@
 	  [original zfast_lcd_standard code copyright (C) 2017 Greg Hogan (SoltanGris42)]
 	
 	- Colour correction code taken from 'gbc-color', written by hunterk and realeased
-	  into the public domain
+	  into the public domain, with further tweaks by Pokefan531
 	
 	Other code by jdgleaver
 	
@@ -121,15 +121,15 @@ const float LINE_WEIGHT_B = 8.0 / 3.0;
 const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 
 // Colour correction
-#define CC_R 0.78824
-#define CC_G 0.72941
-#define CC_B 0.82
-#define CC_RG 0.025
-#define CC_RB 0.12039
-#define CC_GR 0.12157
-#define CC_GB 0.12157
+#define CC_R 0.86629
+#define CC_G 0.70857
+#define CC_B 0.77215
+#define CC_RG 0.02429
+#define CC_RB 0.11337
+#define CC_GR 0.13361
+#define CC_GB 0.11448
 #define CC_BR 0.0
-#define CC_BG 0.275000
+#define CC_BG 0.26714
 
 /*
     FRAGMENT SHADER

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.slang
@@ -8,7 +8,7 @@
 	  [original zfast_lcd_standard code copyright (C) 2017 Greg Hogan (SoltanGris42)]
 	
 	- Colour correction code taken from 'gbc-color', written by hunterk and realeased
-	  into the public domain
+	  into the public domain, with further tweaks by Pokefan531
 	
 	Other code by jdgleaver
 	
@@ -121,15 +121,15 @@ const float LINE_WEIGHT_B = 8.0 / 3.0;
 const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 
 // Colour correction
-#define CC_R 0.78824
-#define CC_G 0.72941
-#define CC_B 0.82
-#define CC_RG 0.025
-#define CC_RB 0.12039
-#define CC_GR 0.12157
-#define CC_GB 0.12157
+#define CC_R 0.86629
+#define CC_G 0.70857
+#define CC_B 0.77215
+#define CC_RG 0.02429
+#define CC_RB 0.11337
+#define CC_GR 0.13361
+#define CC_GB 0.11448
 #define CC_BR 0.0
-#define CC_BG 0.275000
+#define CC_BG 0.26714
 
 /*
     FRAGMENT SHADER


### PR DESCRIPTION
This pull request just updates the simpletex_lcd+gbc-color shaders with the new colour correction values from version 10.0 of Pokefan531's gbc-color shader ([src](https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/160))