### PR TITLE
WIP: Add condition to not draw border over screen.

### DIFF
--- a/handheld/console-border/shader-files/gb-pass-5.slang
+++ b/handheld/console-border/shader-files/gb-pass-5.slang
@@ -7,11 +7,13 @@ layout(push_constant) uniform Push
 	float SCALE;
 	float OUT_X;
 	float OUT_Y;
+	float border_on_top;
 } params;
 
 #pragma parameter SCALE "Box Scale" 0.6667 0.6667 1.5 0.33333
 #pragma parameter OUT_X "Out X" 1600.0 1600.0 4800.0 8000.0
 #pragma parameter OUT_Y "Out Y" 800.0 800.0 2400.0 400.0
+#pragma parameter border_on_top "Show Viewport" 1.0 0.0 1.0 1.0
 
 layout(std140, set = 0, binding = 0) uniform UBO
 {
@@ -48,5 +50,9 @@ void main()
 {
 	vec4 frame	=	texture(Source, vTexCoord).rgba;
 	vec4 border	=	texture(BORDER, tex_border).rgba;
+	
+	if ( vTexCoord.x < 0.9999 && vTexCoord.x > 0.0001 && vTexCoord.y < 0.9999 && vTexCoord.y > 0.0001 && params.border_on_top > 0.5 )
+	border.a *= 0.0;
+
 	FragColor	=	vec4(mix(frame, border, border.a));
 }


### PR DESCRIPTION
Please do not merge this yet, as it's a WIP.

Some handheld console borders have a light reflection effect present in the border texture with alpha to make them transparent.
This light reflection effect might not be to the taste of everyone, since it's degrading the original picture quality and might be annoying, as seen on the top right corner of this picture.

![image](https://user-images.githubusercontent.com/11202422/48623763-87602900-e9a2-11e8-98c0-2bb3ae4b7421.png)

I propose a shader parameter that enables/disables the alpha of the texture to simulate enabling/disabling the light reflection effect. I started with this code, but I have no knowledge of slang shader programming and might need some help.

The current code, adapted from `slang-shaders/handheld/console-border/shader-files/border.slang` works nicely for most shaders, but it seems to break the DMG, GBP and some GBA border shaders, perhaps because the `vTexCoord` can not be used in the same fashion as the other border shaders.

Some help would be appreciated.