### PR TITLE
add stock presets

### DIFF
--- a/bilinear.slangp
+++ b/bilinear.slangp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = stock.slang
+filter_linear0 = true

--- a/nearest.slangp
+++ b/nearest.slangp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = stock.slang
+filter_linear0 = false


### PR DESCRIPTION
## Description

Adds bilinear.slangp and nearest.slangp to make it slightly more intuitive to load stock shaders.
Stock shaders are useful as a sort of "shader blacklist" for content if saved as a global/core/folder/game preset.

## Related Pull Requests

Sort of related and motivated by https://github.com/libretro/RetroArch/pull/9315 and https://github.com/libretro/RetroArch/pull/9320