### PR TITLE
Update crt-guest-dr-venom-ntsc-composite-stock.slangp

### DIFF
--- a/presets/crt-guest-dr-venom-ntsc-composite-stock.slangp
+++ b/presets/crt-guest-dr-venom-ntsc-composite-stock.slangp
@@ -36,42 +36,46 @@ SamplerLUT2_linear = true
 SamplerLUT3 = ../crt/shaders/guest/lut/other1.png
 SamplerLUT3_linear = true 
 
-shader4 = ../crt/shaders/guest/d65-d50.slang
-filter_linear4 = false
+shader4 = ../crt/shaders/guest/color-profiles.slang
+filter_linear4 = true
 scale_type4 = source
 scale4 = 1.0
-alias4 = WhitePointPass
 
-shader5 = ../stock.slang
-filter_linear5 = false
+shader5 = ../crt/shaders/guest/d65-d50.slang
+filter_linear5 = true
 scale_type5 = source
 scale5 = 1.0
+alias5 = WhitePointPass
 
-shader6 = ../stock.slang
-filter_linear6 = false
+shader6 = ../crt/shaders/guest/afterglow.slang
+filter_linear6 = true
 scale_type6 = source
 scale6 = 1.0
+alias6 = AfterglowPass
 
-shader7 = ../stock.slang
-filter_linear7 = false
+shader7 = ../crt/shaders/guest/avg-lum.slang
+filter_linear7 = true
 scale_type7 = source
 scale7 = 1.0
+mipmap_input7 = true
+float_framebuffer7 = true
+alias7 = AvgLumPass
 
 shader8 = ../crt/shaders/guest/linearize.slang
-filter_linear8 = false
+filter_linear8 = true
 scale_type8 = source
 scale8 = 1.0
 float_framebuffer8 = true
 alias8 = LinearizePass
 
 shader9 = ../crt/shaders/guest/blur_horiz.slang
-filter_linear9 = false
+filter_linear9 = true
 scale_type9 = source
 scale9 = 1.0
 float_framebuffer9 = true
 
 shader10 = ../crt/shaders/guest/blur_vert.slang
-filter_linear10 = false
+filter_linear10 = true
 scale_type10 = source
 scale10 = 1.0
 float_framebuffer10 = true


### PR DESCRIPTION
Updated to latest crt-guest-dr-venom-ntsc-composite. To run a high internal res and then downsample just the Y axis.