### PR TITLE
Update crt-guest-dr-venom-stock.slangp

### DIFF
--- a/presets/crt-guest-dr-venom-stock.slangp
+++ b/presets/crt-guest-dr-venom-stock.slangp
@@ -1,4 +1,4 @@
-shaders = 12
+shaders = 11
 
 shader0 = ../stock.slang
 filter_linear0 = false
@@ -20,59 +20,58 @@ SamplerLUT3 = ../crt/shaders/guest/lut/other1.png
 SamplerLUT3_linear = true 
 
 shader2 = ../crt/shaders/guest/color-profiles.slang
-filter_linear2 = false
+filter_linear2 = true
 scale_type2 = source
 scale2 = 1.0
 
 shader3 = ../crt/shaders/guest/d65-d50.slang
-filter_linear3 = false
+filter_linear3 = true
 scale_type3 = source
 scale3 = 1.0
 alias3 = WhitePointPass
 
-shader4 = ../stock.slang
-filter_linear4 = false
+shader4 = ../crt/shaders/guest/afterglow.slang
+filter_linear4 = true
 scale_type4 = source
 scale4 = 1.0
+alias4 = AfterglowPass
 
-shader5 = ../stock.slang
-filter_linear5 = false
+shader5 = ../crt/shaders/guest/avg-lum.slang
+filter_linear5 = true
 scale_type5 = source
 scale5 = 1.0
+mipmap_input5 = true
+float_framebuffer5 = true
+alias5 = AvgLumPass
 
-shader6 = ../stock.slang
-filter_linear6 = false
+shader6 = ../crt/shaders/guest/linearize.slang
+filter_linear6 = true
 scale_type6 = source
 scale6 = 1.0
+float_framebuffer6 = true
+alias6 = LinearizePass
 
-shader7 = ../crt/shaders/guest/linearize.slang
-filter_linear7 = false
+shader7 = ../crt/shaders/guest/blur_horiz.slang
+filter_linear7 = true
 scale_type7 = source
 scale7 = 1.0
 float_framebuffer7 = true
-alias7 = LinearizePass
 
-shader8 = ../crt/shaders/guest/blur_horiz.slang
-filter_linear8 = false
+shader8 = ../crt/shaders/guest/blur_vert.slang
+filter_linear8 = true
 scale_type8 = source
 scale8 = 1.0
 float_framebuffer8 = true
+alias8 = GlowPass
 
-shader9 = ../crt/shaders/guest/blur_vert.slang
-filter_linear9 = false
+shader9 = ../crt/shaders/guest/linearize_scanlines.slang
+filter_linear9 = true
 scale_type9 = source
 scale9 = 1.0
 float_framebuffer9 = true
-alias9 = GlowPass
 
-shader10 = ../crt/shaders/guest/linearize_scanlines.slang
+shader10 = ../crt/shaders/guest/crt-guest-dr-venom.slang
 filter_linear10 = true
-scale_type10 = source
-scale10 = 1.0
-float_framebuffer10 = true
-
-shader11 = ../crt/shaders/guest/crt-guest-dr-venom.slang
-filter_linear11 = true
-scale_type11 = viewport
-scale_x11 = 1.0
-scale_y11 = 1.0
+scale_type10 = viewport
+scale_x10 = 1.0
+scale_y10 = 1.0


### PR DESCRIPTION
Updated to latest crt-guest-dr-venom. To run a high internal res and then downsample just the Y axis.