### PR TITLE
Add lcd1x shaders

### DIFF
--- a/handheld/lcd1x.slangp
+++ b/handheld/lcd1x.slangp
@@ -1,0 +1,10 @@
+shaders = "1"
+
+shader0 = "shaders/lcd1x.slang"
+
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+mipmap_input0 = "false"
+alias0 = ""
+float_framebuffer0 = "false"
+srgb_framebuffer0 = "false"

--- a/handheld/lcd1x_nds.slangp
+++ b/handheld/lcd1x_nds.slangp
@@ -1,0 +1,10 @@
+shaders = "1"
+
+shader0 = "shaders/lcd1x_nds.slang"
+
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+mipmap_input0 = "false"
+alias0 = ""
+float_framebuffer0 = "false"
+srgb_framebuffer0 = "false"

--- a/handheld/lcd1x_psp.slangp
+++ b/handheld/lcd1x_psp.slangp
@@ -1,0 +1,10 @@
+shaders = "1"
+
+shader0 = "shaders/lcd1x_psp.slang"
+
+filter_linear0 = "false"
+wrap_mode0 = "clamp_to_border"
+mipmap_input0 = "false"
+alias0 = ""
+float_framebuffer0 = "false"
+srgb_framebuffer0 = "false"

--- a/handheld/shaders/lcd1x.slang
+++ b/handheld/shaders/lcd1x.slang
@@ -1,0 +1,83 @@
+#version 450
+
+/*
+   lcd1x shader
+
+   A slightly tweaked version of lcd3x, original code written by Gigaherz
+   and released into the public domain:
+
+   > Omits LCD 'colour seperation' effect
+
+   > Has 'properly' aligned scanlines
+
+   Edited by jdgleaver
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 2 of the License, or (at your option)
+   any later version.
+*/
+
+#pragma parameter BRIGHTEN_SCANLINES "Brighten Scanlines" 16.0 1.0 32.0 0.5
+#pragma parameter BRIGHTEN_LCD "Brighten LCD" 4.0 1.0 12.0 0.1
+
+layout(push_constant) uniform Push
+{
+   float BRIGHTEN_SCANLINES;
+   float BRIGHTEN_LCD;
+   vec4 OutputSize;
+   vec4 OriginalSize;
+   vec4 SourceSize;
+} registers;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+   mat4 MVP;
+} global;
+
+#pragma stage vertex
+
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+/*
+   VERTEX_SHADER
+*/
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+// Magic Numbers
+#define PI 3.141592654
+
+/*
+   FRAGMENT SHADER
+*/
+void main()
+{
+   // Generate LCD grid effect
+   // > Note the 0.25 pixel offset -> required to ensure that
+   //   scanlines occur *between* pixels
+   vec2 pixelCoord = vTexCoord.xy * registers.SourceSize.xy;
+   vec2 angle = 2.0 * PI * (pixelCoord - 0.25);
+
+   float yfactor = (registers.BRIGHTEN_SCANLINES + sin(angle.y)) / (registers.BRIGHTEN_SCANLINES + 1.0);
+   float xfactor = (registers.BRIGHTEN_LCD + sin(angle.x)) / (registers.BRIGHTEN_LCD + 1.0);
+
+   // Get colour sample
+   vec3 colour = texture(Source, registers.SourceSize.zw * pixelCoord.xy).rgb;
+
+   // Apply LCD grid effect
+   colour.rgb = yfactor * xfactor * colour.rgb;
+
+   FragColor = vec4(colour.rgb, 1.0);
+}

--- a/handheld/shaders/lcd1x_nds.slang
+++ b/handheld/shaders/lcd1x_nds.slang
@@ -1,0 +1,116 @@
+#version 450
+
+/*
+   lcd1x_nds shader
+
+   A slightly tweaked version of lcd3x:
+
+   - Original lcd3x code written by Gigaherz and released into the public domain
+
+   - Original 'nds_color' code written by hunterk, modified by Pokefan531 and
+     released into the public domain
+
+   Notes:
+
+   > Omits LCD 'colour seperation' effect
+
+   > Has 'properly' aligned scanlines
+
+   > Includes NDS colour correction
+
+   > Supports any NDS internal resolution setting
+
+   Edited by jdgleaver
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 2 of the License, or (at your option)
+   any later version.
+*/
+
+#pragma parameter BRIGHTEN_SCANLINES "Brighten Scanlines" 16.0 1.0 32.0 0.5
+#pragma parameter BRIGHTEN_LCD "Brighten LCD" 4.0 1.0 12.0 0.1
+
+layout(push_constant) uniform Push
+{
+   float BRIGHTEN_SCANLINES;
+   float BRIGHTEN_LCD;
+   vec4 OutputSize;
+   vec4 OriginalSize;
+   vec4 SourceSize;
+} registers;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+   mat4 MVP;
+} global;
+
+#pragma stage vertex
+
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+/*
+   VERTEX_SHADER
+*/
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+// Magic Numbers
+#define PI 3.141592654
+
+#define NDS_SCREEN_HEIGHT 192.0
+
+#define TARGET_GAMMA 2.2
+const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
+#define CC_R 0.85
+#define CC_G 0.655
+#define CC_B 0.865
+#define CC_RG 0.095
+#define CC_RB 0.06
+#define CC_GR 0.20
+#define CC_GB 0.075
+#define CC_BR -0.05
+#define CC_BG 0.25
+
+/*
+   FRAGMENT SHADER
+*/
+void main()
+{
+   // Generate LCD grid effect
+   // > Note the 0.25 pixel offset -> required to ensure that
+   //   scanlines occur *between* pixels
+   // > Divide pixel coordinate by current scale factor
+   //   (input_video_height / nds_screen_height)
+   vec2 pixelCoord = vTexCoord.xy * registers.SourceSize.xy;
+   vec2 angle = 2.0 * PI * ((pixelCoord * NDS_SCREEN_HEIGHT * registers.SourceSize.w) - 0.25);
+
+   float yfactor = (registers.BRIGHTEN_SCANLINES + sin(angle.y)) / (registers.BRIGHTEN_SCANLINES + 1.0);
+   float xfactor = (registers.BRIGHTEN_LCD + sin(angle.x)) / (registers.BRIGHTEN_LCD + 1.0);
+
+   // Get colour sample
+   vec3 colour = texture(Source, registers.SourceSize.zw * pixelCoord.xy).rgb;
+
+   // Apply colour correction
+   colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA));
+   colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
+                     CC_GR, CC_G,  CC_GB,
+                     CC_BR, CC_BG, CC_B) * colour.rgb;
+   colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
+
+   // Apply LCD grid effect
+   colour.rgb = yfactor * xfactor * colour.rgb;
+
+   FragColor = vec4(colour.rgb, 1.0);
+}

--- a/handheld/shaders/lcd1x_psp.slang
+++ b/handheld/shaders/lcd1x_psp.slang
@@ -1,0 +1,116 @@
+#version 450
+
+/*
+   lcd1x_psp shader
+
+   A slightly tweaked version of lcd3x:
+
+   - Original lcd3x code written by Gigaherz and released into the public domain
+
+   - Original 'psp_color' code written by hunterk, modified by Pokefan531 and
+     released into the public domain
+
+   Notes:
+
+   > Omits LCD 'colour seperation' effect
+
+   > Has 'properly' aligned scanlines
+
+   > Includes PSP colour correction
+
+   > Supports any PSP internal resolution setting
+
+   Edited by jdgleaver
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 2 of the License, or (at your option)
+   any later version.
+*/
+
+#pragma parameter BRIGHTEN_SCANLINES "Brighten Scanlines" 16.0 1.0 32.0 0.5
+#pragma parameter BRIGHTEN_LCD "Brighten LCD" 4.0 1.0 12.0 0.1
+
+layout(push_constant) uniform Push
+{
+   float BRIGHTEN_SCANLINES;
+   float BRIGHTEN_LCD;
+   vec4 OutputSize;
+   vec4 OriginalSize;
+   vec4 SourceSize;
+} registers;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+   mat4 MVP;
+} global;
+
+#pragma stage vertex
+
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+/*
+   VERTEX_SHADER
+*/
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord   = TexCoord;
+}
+
+#pragma stage fragment
+
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+// Magic Numbers
+#define PI 3.141592654
+
+#define PSP_SCREEN_HEIGHT 272.0
+
+#define TARGET_GAMMA 2.21
+const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
+#define CC_R 0.98
+#define CC_G 0.795
+#define CC_B 0.98
+#define CC_RG 0.04
+#define CC_RB 0.01
+#define CC_GR 0.20
+#define CC_GB 0.01
+#define CC_BR -0.18
+#define CC_BG 0.165
+
+/*
+   FRAGMENT SHADER
+*/
+void main()
+{
+   // Generate LCD grid effect
+   // > Note the 0.25 pixel offset -> required to ensure that
+   //   scanlines occur *between* pixels
+   // > Divide pixel coordinate by current scale factor
+   //   (input_video_height / psp_screen_height)
+   vec2 pixelCoord = vTexCoord.xy * registers.SourceSize.xy;
+   vec2 angle = 2.0 * PI * ((pixelCoord * PSP_SCREEN_HEIGHT * registers.SourceSize.w) - 0.25);
+
+   float yfactor = (registers.BRIGHTEN_SCANLINES + sin(angle.y)) / (registers.BRIGHTEN_SCANLINES + 1.0);
+   float xfactor = (registers.BRIGHTEN_LCD + sin(angle.x)) / (registers.BRIGHTEN_LCD + 1.0);
+
+   // Get colour sample
+   vec3 colour = texture(Source, registers.SourceSize.zw * pixelCoord.xy).rgb;
+
+   // Apply colour correction
+   colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA));
+   colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
+                     CC_GR, CC_G,  CC_GB,
+                     CC_BR, CC_BG, CC_B) * colour.rgb;
+   colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
+
+   // Apply LCD grid effect
+   colour.rgb = yfactor * xfactor * colour.rgb;
+
+   FragColor = vec4(colour.rgb, 1.0);
+}


### PR DESCRIPTION
This PR adds a very simple/trivial `lcd1x` handheld shader that is almost identical to `lcd3x` but:

- Omits the colour separation effect (this always gives me eye-strain...)

- Has scanlines that properly align with pixel columns/rows

Here are a couple of example screenshots:

![Shantae (USA) (GBC)-200629-110437](https://user-images.githubusercontent.com/38211560/85998641-fc129a80-ba02-11ea-8ea6-62b9c4983104.png)

![Wario Land 4 (USA, Europe)-200629-110819](https://user-images.githubusercontent.com/38211560/85998651-ff0d8b00-ba02-11ea-833c-db2d8f06f1b7.png)

The nice thing about this shader is that it handles low display resolutions quite well, producing even scanlines regardless of scaling. It also has minimal performance impact.

One interesting use case is applying it to PSX content on a phone with a 720p display:

![Alundra (USA) (v1 1)-200629-120009](https://user-images.githubusercontent.com/38211560/85999056-7d6a2d00-ba03-11ea-87c2-8cc034b8b445.png)

![Legend of Mana (USA)-200629-113809](https://user-images.githubusercontent.com/38211560/85999124-91ae2a00-ba03-11ea-875a-cdd6d2bb114e.png)

This 'feels' very much like running PSX games on an idealised PSP.

In addition to the base `lcd1x` shader, two device-specific variants are included:

- `lcd1x_nds`: This applies NDS colour correction, and can be used with arbitrary internal scale factors:

`720p`

![Super Mario 64 DS (Europe) (En,Fr,De,Es,It)  ! -200629-112507](https://user-images.githubusercontent.com/38211560/85999561-3466a880-ba04-11ea-8653-8ca60d8c0937.png)

`1080p`

![Super Mario 64 DS (Europe) (En,Fr,De,Es,It)  ! -200629-112630](https://user-images.githubusercontent.com/38211560/85999578-3d577a00-ba04-11ea-846f-d22d06d2f6ed.png)

- `lcd1x_psp`: This applies PSP colour correction, and can also be used with arbitrary internal scale factors:

`720p`

![Crimson Gem Saga (USA) (UMD) (ULUS10400)-200629-114627](https://user-images.githubusercontent.com/38211560/85999667-637d1a00-ba04-11ea-8725-581c344ed4fa.png)

`1080p`

![Crimson Gem Saga (USA) (UMD) (ULUS10400)-200629-114440](https://user-images.githubusercontent.com/38211560/85999678-6972fb00-ba04-11ea-873c-e6ec63d69ce0.png)

`720p - high internal scaling`

![Wipeout Pure (EUR) (UMD) (UCES00001)-200629-115205](https://user-images.githubusercontent.com/38211560/85999723-7d1e6180-ba04-11ea-9588-c441e5e0c7ca.png)
