### PR TITLE
Fixed round dots on Gameboy shaders

### DIFF
--- a/handheld/console-border/gb-pocket-2x.slangp
+++ b/handheld/console-border/gb-pocket-2x.slangp
@@ -35,14 +35,15 @@ filter_linear5 = true
 scale_type5 = source
 scale5 = 1.0
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;contrast;screen_light;pixel_opacity;shadow_offset_x"
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;shadow_offset_x"
 video_scale = "3.0"
 SCALE = "0.6667"
 OUT_X = "1600.0"
 OUT_Y = "800.0"
 baseline_alpha = "0.03"
 grey_balance = "3.5"
-contrast = "0.8"
+adjacent_texel_alpha_blending = "0.6"
+contrast = "0.85"
 screen_light = "0.9"
 pixel_opacity = "0.95"
 shadow_opacity = "0.9"

--- a/handheld/console-border/gb-pocket-3x.slangp
+++ b/handheld/console-border/gb-pocket-3x.slangp
@@ -33,14 +33,15 @@ alias4 = "PASS4"
 shader5 = shader-files/gb-pass-5.slang
 filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;contrast;screen_light;pixel_opacity;shadow_offset_x"
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;shadow_offset_x"
 video_scale = "3.0"
 SCALE = "1.0"
 OUT_X = "2400.0"
 OUT_Y = "1200.0"
 baseline_alpha = "0.03"
 grey_balance = "3.5"
-contrast = "0.8"
+adjacent_texel_alpha_blending = "0.6"
+contrast = "0.85"
 screen_light = "0.9"
 pixel_opacity = "0.95"
 shadow_opacity = "0.9"

--- a/handheld/console-border/gb-pocket-4x.slangp
+++ b/handheld/console-border/gb-pocket-4x.slangp
@@ -33,14 +33,15 @@ alias4 = "PASS4"
 shader5 = shader-files/gb-pass-5.slang
 filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;contrast;screen_light;pixel_opacity;shadow_offset_x"
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;shadow_offset_x"
 video_scale = "4.0"
 SCALE = "1.0"
 OUT_X = "3200.0"
 OUT_Y = "1600.0"
 baseline_alpha = "0.03"
 grey_balance = "3.5"
-contrast = "0.8"
+adjacent_texel_alpha_blending = "0.6"
+contrast = "0.85"
 screen_light = "0.9"
 pixel_opacity = "0.95"
 shadow_opacity = "0.9"

--- a/handheld/console-border/gb-pocket-5x.slangp
+++ b/handheld/console-border/gb-pocket-5x.slangp
@@ -33,14 +33,15 @@ alias4 = "PASS4"
 shader5 = shader-files/gb-pass-5.slang
 filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;contrast;screen_light;pixel_opacity;shadow_offset_x"
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;shadow_offset_x"
 video_scale = "4.0"
 SCALE = "1.25"
 OUT_X = "4000.0"
 OUT_Y = "2000.0"
 baseline_alpha = "0.03"
 grey_balance = "3.5"
-contrast = "0.8"
+adjacent_texel_alpha_blending = "0.6"
+contrast = "0.85"
 screen_light = "0.9"
 pixel_opacity = "0.95"
 shadow_opacity = "0.9"

--- a/handheld/console-border/gb-pocket-6x.slangp
+++ b/handheld/console-border/gb-pocket-6x.slangp
@@ -33,14 +33,15 @@ alias4 = "PASS4"
 shader5 = shader-files/gb-pass-5.slang
 filter_linear5 = true
 
-parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;contrast;screen_light;pixel_opacity;shadow_offset_x"
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;baseline_alpha;grey_balance;adjacent_texel_alpha_blending;contrast;screen_light;pixel_opacity;shadow_offset_x"
 video_scale = "4.0"
 SCALE = "1.5"
 OUT_X = "4800.0"
 OUT_Y = "2400.0"
 baseline_alpha = "0.03"
 grey_balance = "3.5"
-contrast = "0.8"
+adjacent_texel_alpha_blending = "0.6"
+contrast = "0.85"
 screen_light = "0.9"
 pixel_opacity = "0.95"
 shadow_opacity = "0.9"

--- a/handheld/console-border/shader-files/gb-pass0.slang
+++ b/handheld/console-border/shader-files/gb-pass0.slang
@@ -26,7 +26,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #pragma parameter baseline_alpha "Baseline Alpha" 0.05 0.0 1.0 0.01
 
 // Fine-tune the balance between the different shades of grey
-#pragma parameter grey_balance "Grey Balance" 2.6 2.0 4.0 0.1
+#pragma parameter grey_balance "Grey Balance" 2.7 2.0 4.0 0.1
 
 // Simulate response time
 // Higher values result in longer color transition periods - [0, 1]

--- a/handheld/console-border/shader-files/gb-pass1.slang
+++ b/handheld/console-border/shader-files/gb-pass1.slang
@@ -23,7 +23,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #pragma parameter blending_mode "Blending Mode" 0.0 0.0 1.0 1.0            
 
 // The amount of alpha swapped between neighboring texels
-#pragma parameter adjacent_texel_alpha_blending "Neighbor Blending" 0.38 0.0 1.0 0.05
+#pragma parameter adjacent_texel_alpha_blending "Neighbor Blending" 0.76 0.0 1.0 0.01
 
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //
@@ -59,8 +59,12 @@ layout(location = 2) out vec2 blur_coords_up;
 layout(location = 3) out vec2 blur_coords_down;
 layout(location = 4) out vec2 blur_coords_right;
 layout(location = 5) out vec2 blur_coords_left;
-layout(location = 6) out vec2 blur_coords_lower_bound;
-layout(location = 7) out vec2 blur_coords_upper_bound;
+layout(location = 6) out vec2 blur_coords_upright;
+layout(location = 7) out vec2 blur_coords_upleft;
+layout(location = 8) out vec2 blur_coords_downright;
+layout(location = 9) out vec2 blur_coords_downleft;
+layout(location = 10) out vec2 blur_coords_lower_bound;
+layout(location = 11) out vec2 blur_coords_upper_bound;
 
 void main()
 {
@@ -68,10 +72,15 @@ void main()
     vTexCoord = TexCoord;
 
     texel = registers.SourceSize.zw;
-    blur_coords_down  = vTexCoord + vec2(0.0, texel.y);
-    blur_coords_up    = vTexCoord + vec2(0.0, -texel.y);
-    blur_coords_right = vTexCoord + vec2(texel.x,  0.0);
-    blur_coords_left  = vTexCoord + vec2(-texel.x, 0.0);
+    blur_coords_down      = vTexCoord + vec2(0.0, texel.y);
+    blur_coords_up        = vTexCoord + vec2(0.0, -texel.y);
+    blur_coords_right     = vTexCoord + vec2(texel.x,  0.0);
+    blur_coords_left      = vTexCoord + vec2(-texel.x, 0.0);
+    blur_coords_downright = vTexCoord + vec2(texel.x, texel.y);
+    blur_coords_downleft  = vTexCoord + vec2(-texel.x, texel.y);
+    blur_coords_upright   = vTexCoord + vec2(texel.x, -texel.y);
+    blur_coords_upleft    = vTexCoord + vec2(-texel.x, -texel.y);
+
     blur_coords_lower_bound = vec2(0.0);
     blur_coords_upper_bound = texel * (registers.OutputSize.xy - vec2(2.0));
 }
@@ -87,8 +96,12 @@ layout(location = 2) in vec2 blur_coords_up;
 layout(location = 3) in vec2 blur_coords_down;
 layout(location = 4) in vec2 blur_coords_right;
 layout(location = 5) in vec2 blur_coords_left;
-layout(location = 6) in vec2 blur_coords_lower_bound;
-layout(location = 7) in vec2 blur_coords_upper_bound;
+layout(location = 6) in vec2 blur_coords_upright;
+layout(location = 7) in vec2 blur_coords_upleft;
+layout(location = 8) in vec2 blur_coords_downright;
+layout(location = 9) in vec2 blur_coords_downleft;
+layout(location = 10) in vec2 blur_coords_lower_bound;
+layout(location = 11) in vec2 blur_coords_upper_bound;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 
@@ -96,40 +109,93 @@ layout(set = 0, binding = 2) uniform sampler2D Source;
 // Fragment definitions                                                       //
 ////////////////////////////////////////////////////////////////////////////////
 
-float blending_modifier(float color){
-	float blend_bool = (color == 0.0) ? 1 : 0;
-	return clamp(blend_bool + registers.blending_mode, 0.0, 1.0);
+// Clamp the blur coords to the input texture size so it doesn't attempt to sample off the texture (it'll retrieve float4(0.0) and darken the edges otherwise)
+// Then return its alpha
+float clamped_coord_alpha(vec2 blur_coords)
+{
+    vec2 clamped_coord = clamp(blur_coords, blur_coords_lower_bound, blur_coords_upper_bound);
+    return texture(Source, clamped_coord).a;
+}
+
+// Used for gap direction detection
+bool is_gap(vec2 coords_side_1, vec2 coords_side_2)
+{
+    float alpha_side_1 = texture(Source, coords_side_1).a;
+    float alpha_side_2 = texture(Source, coords_side_2).a;
+
+    return alpha_side_1 == 0.0 && alpha_side_2 == 0.0;
+}
+
+// A simple blur technique that softens harsh color transitions
+// Specialized to only blur alpha values
+// Blends only the texels between dots
+vec4 blend_gap_mode(vec4 out_color)
+{
+    if(out_color.a == 0.0)
+    {
+        // Check if our gap is horizontal or vertical
+        bool is_gap_horizontal = is_gap(blur_coords_left, blur_coords_right);
+        bool is_gap_vertical = is_gap(blur_coords_up, blur_coords_down);
+
+        // When in a gap interesection, average the 4 diagonal dots
+        if(is_gap_horizontal && is_gap_vertical)
+        {
+            // Set the current fragment alpha value to the average of alpha differences between neighboring texels
+            out_color.a =
+            (
+                (clamped_coord_alpha(blur_coords_upleft) - out_color.a) +
+                (clamped_coord_alpha(blur_coords_upright) - out_color.a) +
+                (clamped_coord_alpha(blur_coords_downleft) - out_color.a) +
+                (clamped_coord_alpha(blur_coords_downright) - out_color.a)
+            ) / 4;
+        }
+        // When in an horizontal gap, average the above and bellow texels
+        else if(is_gap_horizontal)
+        {
+            out_color.a =
+            (
+                (clamped_coord_alpha(blur_coords_up) - out_color.a) +
+                (clamped_coord_alpha(blur_coords_down) - out_color.a)
+            ) / 2;
+        }
+        // When in a vertical gap, average the left and right texels
+        else if(is_gap_vertical)
+        {
+            out_color.a =
+            (
+                (clamped_coord_alpha(blur_coords_right) - out_color.a) +
+                (clamped_coord_alpha(blur_coords_left) - out_color.a)
+            ) / 2;
+        }
+
+        // Modify the alpha value based on how high the "Neighbor Blending" parameter is set to
+        out_color.a *= registers.adjacent_texel_alpha_blending;
+    }
+
+    return out_color;
+}
+
+// Blends all texels
+vec4 blend_all_mode(vec4 out_color)
+{
+    // Average the alpha differences between neighboring texels, apply the parameter modifier, then sum the result to the current fragment alpha value
+    out_color.a +=
+    (
+        (clamped_coord_alpha(blur_coords_up) - out_color.a) +
+        (clamped_coord_alpha(blur_coords_down) - out_color.a) +
+        (clamped_coord_alpha(blur_coords_right) - out_color.a) +
+        (clamped_coord_alpha(blur_coords_left) - out_color.a)
+    ) / 4 * registers.adjacent_texel_alpha_blending;
+
+    return out_color;
 }
 
 void main()
 {
-    // A simple blur technique that softens harsh color transitions
-    // Specialized to only blur alpha values and limited to only blurring texels
-    // lying in the spaces between two or more texels
-
-    // Sample the input textures
     vec4 out_color = texture(Source, vTexCoord).rgba;
 
-    // Clamp the blur coords to the input texture size so it doesn't attempt to sample off the texture (it'll retrieve float4(0.0) and darken the edges otherwise)
-    vec2 blur_coords_up_clamped    = clamp(blur_coords_up, blur_coords_lower_bound, blur_coords_upper_bound);
-    vec2 blur_coords_down_clamped  = clamp(blur_coords_down, blur_coords_lower_bound, blur_coords_upper_bound);
-    vec2 blur_coords_right_clamped = clamp(blur_coords_right, blur_coords_lower_bound, blur_coords_upper_bound);
-    vec2 blur_coords_left_clamped  = clamp(blur_coords_left, blur_coords_lower_bound, blur_coords_upper_bound);
-
-    //Sample adjacent texels based on the coordinates above
-    vec4 adjacent_texel_1 = texture(Source, blur_coords_up_clamped).rgba;
-    vec4 adjacent_texel_2 = texture(Source, blur_coords_down_clamped).rgba;
-    vec4 adjacent_texel_3 = texture(Source, blur_coords_right_clamped).rgba;
-    vec4 adjacent_texel_4 = texture(Source, blur_coords_left_clamped).rgba;
-
-    // Sum the alpha differences between neighboring texels, apply modifiers, then subtract the result from the current fragment alpha value
-    out_color.a -=  
-    ( 
-        (out_color.a - adjacent_texel_1.a) + 
-        (out_color.a - adjacent_texel_2.a) + 
-        (out_color.a - adjacent_texel_3.a) + 
-        (out_color.a - adjacent_texel_4.a) 
-    ) * registers.adjacent_texel_alpha_blending * blending_modifier(out_color.a);
-
-    FragColor = out_color;
+    if(registers.blending_mode == 1.0)
+        FragColor = blend_all_mode(out_color);
+    else
+        FragColor = blend_gap_mode(out_color);
 }


### PR DESCRIPTION
This fixes the round dots present on the Game Boy border shaders affecting specially the GB Pocket shaders, which I believe were not at all accurate to the geometry of the pixels on a real GB Pocket screen.
The original DMG presets, at their default "Neighbor Blending" parameter values, don't exhibit this problem as much, and as such this change practically doesn't affect their picture at all. This primarily affects the GB Pocket presets only.

This was caused by the fact that the blending shader doesn't blend the intersection of the horizontal and vertical gaps, causing that spot to be much brighter than the rest of the gap.
This pull request changes the way the adjacent texel blending works, by also taking into consideration the intersection texels.

The process is more complex than before, but the performance only dropped by about 8% (from 2400 FPS to 2200 FPS on my RTX 2060).
I tried using float logic instead of branching code but the difference in performance was negligible so I left the branching code like this for readability.

The changes in the parameters are just to compensate for the slight contrast and grey balance change the new code causes on the overall picture. I did it to keep the overall picture as close as possible to the previous version.

This was my first time touching any shader code, so any suggestions or feedback are appreciated! Please forgive any bad spots.

Bellow are some pictures illustrating the visual differences (please open the pictures at native resolution):

Before:
![pocket old crop](https://user-images.githubusercontent.com/11202422/87301478-8ed52e00-c507-11ea-97a2-08d0783fcebc.png)

After:
![pocket new crop](https://user-images.githubusercontent.com/11202422/87301586-bfb56300-c507-11ea-9d70-e4e10fba4939.png)




Before:
![pocket old zoom](https://user-images.githubusercontent.com/11202422/87302613-a1506700-c509-11ea-8dc6-0b1a3d6856c7.png)


After:
![pocket new zoom](https://user-images.githubusercontent.com/11202422/87302622-a7dede80-c509-11ea-87b2-b8d7e74908db.png)
