### PR TITLE
Update GBA/GBC/NDS colour correction parameters

### DIFF
--- a/handheld/shaders/color/gba-color.slang
+++ b/handheld/shaders/color/gba-color.slang
@@ -21,25 +21,25 @@ layout(std140, set = 0, binding = 0) uniform UBO
 */
 // Shader that replicates the LCD dynamics from a GameBoy Advance
 
-#pragma parameter darken_screen "Darken Screen" 0.5 -0.25 1.5 0.05
+#pragma parameter darken_screen "Darken Screen" 1.0 -0.25 1.0 0.05
 
 #define target_gamma 2.2
 #define display_gamma 2.2
 #define sat 1.0
-#define lum 1.0
+#define lum 0.94
 #define contrast 1.0
 #define blr 0.0
 #define blg 0.0
 #define blb 0.0
-#define r 0.86
-#define g 0.66
-#define b 0.81
-#define rg 0.11
-#define rb 0.1325
-#define gr 0.19
-#define gb 0.0575
-#define br -0.05
-#define bg 0.23
+#define r 0.82
+#define g 0.665
+#define b 0.73
+#define rg 0.125
+#define rb 0.195
+#define gr 0.24
+#define gb 0.075
+#define br -0.06
+#define bg 0.21
 #define overscan_percent_x 0.0
 #define overscan_percent_y 0.0
 

--- a/handheld/shaders/color/gbc-color.slang
+++ b/handheld/shaders/color/gbc-color.slang
@@ -2,7 +2,7 @@
 
 layout(push_constant) uniform Push
 {
-   float brighten_screen;
+   float lighten_screen;
 } params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
@@ -19,27 +19,29 @@ layout(std140, set = 0, binding = 0) uniform UBO
    Author: hunterk
    License: Public domain
 */
-// Shader that replicates the LCD dynamics from a GameBoy Advance
+// Shader that replicates the LCD dynamics from a GameBoy Color
 
-#pragma parameter brighten_screen "Brighten Screen" 0.5 -0.25 1.2 0.05
+#pragma parameter lighten_screen "Lighten Screen" 1.0 0.0 1.0 0.05
 
 #define target_gamma 2.2
 #define display_gamma 2.2
 #define sat 1.0
-#define lum 1.0
+#define lum 0.94
 #define contrast 1.0
 #define blr 0.0
 #define blg 0.0
 #define blb 0.0
-#define r 0.87
-#define g 0.66
-#define b 0.79
-#define rg 0.115
-#define rb 0.14
-#define gr 0.18
-#define gb 0.07
-#define br -0.05
-#define bg 0.225
+#define r 0.82
+#define g 0.665
+#define b 0.73
+#define rg 0.125
+#define rb 0.195
+#define gr 0.24
+#define gb 0.075
+#define br -0.06
+#define bg 0.21
+#define overscan_percent_x 0.0
+#define overscan_percent_y 0.0
 
 #pragma stage vertex
 layout(location = 0) in vec4 Position;
@@ -59,7 +61,7 @@ layout(set = 0, binding = 2) uniform sampler2D Source;
 
 void main()
 {
-   vec4 screen = pow(texture(Source, vTexCoord), vec4(target_gamma + (params.brighten_screen * -1.0))).rgba;
+   vec4 screen = pow(texture(Source, vTexCoord), vec4(target_gamma + (params.lighten_screen * -1.0))).rgba;
    vec4 avglum = vec4(0.5);
    screen = mix(screen, avglum, (1.0 - contrast));
    

--- a/handheld/shaders/color/nds-color.slang
+++ b/handheld/shaders/color/nds-color.slang
@@ -14,27 +14,41 @@ layout(std140, set = 0, binding = 0) uniform UBO
    Author: hunterk
    License: Public domain
 */
-// Shader that replicates the LCD dynamics from a Nintendo DS Phat
+// Shader that replicates the LCD dynamics from a Nintendo DS Phat --
 
-#define target_gamma 2.2
-#define display_gamma 2.2
+#define target_gamma 1.91
+#define display_gamma 1.91
 #define sat 1.0
-#define lum 1.0
+#define lum 0.89
 #define contrast 1.0
 #define blr 0.0
 #define blg 0.0
 #define blb 0.0
-#define r 0.85
-#define g 0.655
-#define b 0.865
-#define rg 0.095
-#define rb 0.06
-#define gr 0.20
-#define gb 0.075
-#define br -0.05
-#define bg 0.25
+#define r 0.87
+#define g 0.645
+#define b 0.73
+#define rg 0.10
+#define rb 0.10
+#define gr 0.255
+#define gb 0.17
+#define br -0.125
+#define bg 0.255
 #define overscan_percent_x 0.0
 #define overscan_percent_y 0.0
+
+/*
+White-NDS
+#define lum 0.98
+#define r 0.83
+#define g 0.625
+#define b 0.785
+#define rg 0.07
+#define rb 0.075
+#define gr 0.22
+#define gb 0.155
+#define br -0.13
+#define bg 0.22
+*/
 
 #pragma stage vertex
 layout(location = 0) in vec4 Position;

--- a/handheld/shaders/lcd1x_nds.slang
+++ b/handheld/shaders/lcd1x_nds.slang
@@ -71,17 +71,18 @@ layout(set = 0, binding = 2) uniform sampler2D Source;
 
 #define NDS_SCREEN_HEIGHT 192.0
 
-#define TARGET_GAMMA 2.2
-const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.85
-#define CC_G 0.655
-#define CC_B 0.865
-#define CC_RG 0.095
-#define CC_RB 0.06
-#define CC_GR 0.20
-#define CC_GB 0.075
-#define CC_BR -0.05
-#define CC_BG 0.25
+#define TARGET_GAMMA 1.91
+const float INV_DISPLAY_GAMMA = 1.0 / 1.91;
+#define CC_LUM 0.89
+#define CC_R 0.87
+#define CC_G 0.645
+#define CC_B 0.73
+#define CC_RG 0.10
+#define CC_RB 0.10
+#define CC_GR 0.255
+#define CC_GB 0.17
+#define CC_BR -0.125
+#define CC_BG 0.255
 
 /*
    FRAGMENT SHADER
@@ -106,7 +107,7 @@ void main()
    colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA));
    colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
                      CC_GR, CC_G,  CC_GB,
-                     CC_BR, CC_BG, CC_B) * colour.rgb;
+                     CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
    colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 
    // Apply LCD grid effect

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color-4k.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color-4k.slang
@@ -123,15 +123,16 @@ const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86
-#define CC_G 0.66
-#define CC_B 0.81
-#define CC_RG 0.11
-#define CC_RB 0.1325
-#define CC_GR 0.19
-#define CC_GB 0.0575
-#define CC_BR -0.05
-#define CC_BG 0.23
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 /*
     FRAGMENT SHADER
@@ -146,10 +147,10 @@ void main()
 	vec3 colour = texture(Source, registers.SourceSize.zw * imgCenterCoord.xy).rgb;
 	
 	// Darken colours (if required...) and apply colour correction
-	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 0.5 + registers.DARKEN_COLOUR));
+	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 1.0 + registers.DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gba-color.slang
@@ -123,15 +123,16 @@ const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86
-#define CC_G 0.66
-#define CC_B 0.81
-#define CC_RG 0.11
-#define CC_RB 0.1325
-#define CC_GR 0.19
-#define CC_GB 0.0575
-#define CC_BR -0.05
-#define CC_BG 0.23
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 /*
     FRAGMENT SHADER
@@ -146,10 +147,10 @@ void main()
 	vec3 colour = texture(Source, registers.SourceSize.zw * imgCenterCoord.xy).rgb;
 	
 	// Darken colours (if required...) and apply colour correction
-	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 0.5 + registers.DARKEN_COLOUR));
+	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 1.0 + registers.DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color-4k.slang
@@ -123,15 +123,16 @@ const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.87
-#define CC_G 0.66
-#define CC_B 0.79
-#define CC_RG 0.115
-#define CC_RB 0.14
-#define CC_GR 0.18
-#define CC_GB 0.07
-#define CC_BR -0.05
-#define CC_BG 0.225
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 /*
     FRAGMENT SHADER
@@ -149,7 +150,7 @@ void main()
 	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA - 0.5 + registers.DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd+gbc-color.slang
@@ -123,15 +123,16 @@ const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.87
-#define CC_G 0.66
-#define CC_B 0.79
-#define CC_RG 0.115
-#define CC_RB 0.14
-#define CC_GR 0.18
-#define CC_GB 0.07
-#define CC_BR -0.05
-#define CC_BG 0.225
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 /*
     FRAGMENT SHADER
@@ -149,7 +150,7 @@ void main()
 	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA - 0.5 + registers.DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gba-color.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gba-color.slang
@@ -122,15 +122,16 @@ const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.86
-#define CC_G 0.66
-#define CC_B 0.81
-#define CC_RG 0.11
-#define CC_RB 0.1325
-#define CC_GR 0.19
-#define CC_GB 0.0575
-#define CC_BR -0.05
-#define CC_BG 0.23
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 /*
     FRAGMENT SHADER
@@ -145,10 +146,10 @@ void main()
 	vec3 colour = texture(Source, registers.SourceSize.zw * imgCenterCoord.xy).rgb;
 	
 	// Darken colours (if required...) and apply colour correction
-	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 0.5 + registers.DARKEN_COLOUR));
+	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA + 1.0 + registers.DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gbc-color.slang
+++ b/handheld/shaders/simpletex_lcd/simpletex_lcd_720p+gbc-color.slang
@@ -122,15 +122,16 @@ const float INV_BG_TEXTURE_SIZE = 1.0 / BG_TEXTURE_SIZE;
 // Colour correction
 #define TARGET_GAMMA 2.2
 const float INV_DISPLAY_GAMMA = 1.0 / 2.2;
-#define CC_R 0.87
-#define CC_G 0.66
-#define CC_B 0.79
-#define CC_RG 0.115
-#define CC_RB 0.14
-#define CC_GR 0.18
-#define CC_GB 0.07
-#define CC_BR -0.05
-#define CC_BG 0.225
+#define CC_LUM 0.94
+#define CC_R 0.82
+#define CC_G 0.665
+#define CC_B 0.73
+#define CC_RG 0.125
+#define CC_RB 0.195
+#define CC_GR 0.24
+#define CC_GB 0.075
+#define CC_BR -0.06
+#define CC_BG 0.21
 
 /*
     FRAGMENT SHADER
@@ -148,7 +149,7 @@ void main()
 	colour.rgb = pow(colour.rgb, vec3(TARGET_GAMMA - 0.5 + registers.DARKEN_COLOUR));
 	colour.rgb = mat3(CC_R,  CC_RG, CC_RB,
 							CC_GR, CC_G,  CC_GB,
-							CC_BR, CC_BG, CC_B) * colour.rgb;
+							CC_BR, CC_BG, CC_B) * (colour.rgb * CC_LUM);
 	colour.rgb = clamp(pow(colour.rgb, vec3(INV_DISPLAY_GAMMA)), 0.0, 1.0);
 	
 	// Generate grid pattern...

--- a/presets/retro-v2+gba-color.slangp
+++ b/presets/retro-v2+gba-color.slangp
@@ -10,5 +10,5 @@ scale0 = "1.000000"
 filter_linear1 = "false"
 
 parameters = "darken_screen;RETRO_PIXEL_SIZE"
-darken_screen = "0.500000"
+darken_screen = "1.000000"
 RETRO_PIXEL_SIZE = "0.840000"

--- a/presets/retro-v2+gbc-color.slangp
+++ b/presets/retro-v2+gbc-color.slangp
@@ -9,6 +9,6 @@ scale0 = "1.000000"
 
 filter_linear1 = "false"
 
-parameters = "brighten_screen;RETRO_PIXEL_SIZE"
-brighten_screen = "0.500000"
+parameters = "lighten_screen;RETRO_PIXEL_SIZE"
+lighten_screen = "0.500000"
 RETRO_PIXEL_SIZE = "0.840000"


### PR DESCRIPTION
This PR updates Pokefan531's GBA/GBC/NDS colour correction shaders to the latest version: https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/190

It also updates all derived shaders/presets (i.e. the colour-correction versions of lcd1x, simpletex_lcd, etc.)