### PR TITLE
add crt-blurPi slang shader variants

### DIFF
--- a/crt/crt-blurPi-sharp.slangp
+++ b/crt/crt-blurPi-sharp.slangp
@@ -1,0 +1,11 @@
+shaders = 1
+
+shader0 = shaders/crt-blurPi.slang
+filter_linear0 = false
+scale_type0 = viewport
+scale0 = 1.0
+alias0 = "PASS0"
+
+parameters = "blurGain;blurRadius"
+blurGain = "0.5"
+blurRadius = "1.5"

--- a/crt/crt-blurPi-soft.slangp
+++ b/crt/crt-blurPi-soft.slangp
@@ -1,0 +1,7 @@
+shaders = 1
+
+shader0 = shaders/crt-blurPi.slang
+filter_linear0 = true
+scale_type0 = viewport
+scale0 = 1.0
+alias0 = "PASS0"

--- a/crt/shaders/crt-blurPi.slang
+++ b/crt/shaders/crt-blurPi.slang
@@ -1,0 +1,84 @@
+#version 450
+
+/*
+
+- crt-blurPi slang shader -
+
+Looks good on low res screens (640 x 480 or less), providing screen space scanlines.
+Developed on and for the Raspberry Pi.
+
+Made by Oriol Ferrer Mesià (armadillu)
+http://uri.cat
+
+MIT license
+*/
+
+
+layout(push_constant) uniform Push{
+	vec4 SourceSize;
+	vec4 OriginalSize;
+	vec4 OutputSize;
+	uint FrameCount;
+	//params....
+	float scanlineGain;
+	float rgbExtraGain;
+	float blurGain;	
+	float blurRadius;
+}params;
+
+
+#pragma name crt-blurPi
+#pragma parameter scanlineGain "scanlineGain" 	0.30 	0.0 	1.0 	0.05
+#pragma parameter rgbExtraGain "rgbExtraGain" 	0.10 	0.0 	1.0 	0.05
+#pragma parameter blurGain "blurGain" 			0.15 	0.0 	1.0 	0.05
+#pragma parameter blurRadius "blurRadius" 		1.5 	0.1 	3.0 	0.1
+
+layout(std140, set = 0, binding = 0) uniform UBO{
+	mat4 MVP;
+}global;
+
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+#pragma stage vertex
+/////////////////////////////////////////////////////////////////////////////////////////
+
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+layout(location = 1) out vec2 dot_size;
+
+void main(){
+	gl_Position = global.MVP * Position;
+	vTexCoord = TexCoord;
+	dot_size = params.SourceSize.zw;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+#pragma stage fragment
+/////////////////////////////////////////////////////////////////////////////////////////
+
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 1) in vec2 dot_size;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+void main(){
+
+	float time = mod(params.FrameCount / 60.0, params.OutputSize.y);
+
+	const vec2 off = params.blurRadius * dot_size;
+	float srcGain = 1.0f - 0.75f * params.blurGain;
+
+	vec4 blurred = srcGain * (1.0f + params.rgbExtraGain) * texture(Source, vTexCoord) + 
+   				0.25f * params.blurGain * texture(Source, vTexCoord + vec2(-off.x ,0.0f)) +
+   				0.25f * params.blurGain * texture(Source, vTexCoord + vec2(off.x, 0.0f)) +
+   				0.25f * params.blurGain * texture(Source, vTexCoord + vec2(0.0f, off.y))
+   				;
+
+	float scanLine = mod(int(vTexCoord.y * params.OutputSize.y), 2.0f);
+
+	FragColor = mix(1.0f, scanLine * scanLine, params.scanlineGain) * blurred;
+
+}

--- a/crt/shaders/crt-blurPi.slang
+++ b/crt/shaders/crt-blurPi.slang
@@ -66,7 +66,6 @@ layout(set = 0, binding = 2) uniform sampler2D Source;
 
 void main(){
 
-	float time = mod(params.FrameCount / 60.0, params.OutputSize.y);
 
 	const vec2 off = params.blurRadius * dot_size;
 	float srcGain = 1.0f - 0.75f * params.blurGain;


### PR DESCRIPTION
I've created a low overhead shader for low res screens (640 x 480 or less), mostly targeted towards raspberry pi 4.

The unique thing about it is that it provides customizable scanlines that are rendered independently from the game resolution, as well as configurable softness / blur. This is very useful when your screen has few pixels, as in most other shaders with scanlines they always seem to stand out. It comes with two variants, one based on the nearest neighbor interpolation, and one based on the linear interoplation.

Those don't look that great here (on a retina screen) but they do look fine on a 640 x 480 LCD on a rpi4.

![svcsplus-201022-013741](https://user-images.githubusercontent.com/167057/96802238-be021200-1409-11eb-9ba0-20212c984eca.png)
crt-blurPi-soft.slangp


![svcsplus-201022-013725](https://user-images.githubusercontent.com/167057/96802246-c22e2f80-1409-11eb-8d3d-e3b80b4022df.png)
crt-blurPi-sharp.slangp
