### PR TITLE
fix zfast_crt for rotated games

### DIFF
--- a/crt/shaders/zfast_crt.slang
+++ b/crt/shaders/zfast_crt.slang
@@ -95,10 +95,10 @@ void main()
 	float YY = Y*Y;
 	
 #if defined(FINEMASK) 
-	float whichmask = fract( gl_FragCoord.x*-0.4999);
+	float whichmask = fract(floor(vTexCoord.x*params.OutputSize.x*-0.4999));
 	float mask = 1.0 + float(whichmask < 0.5) * -MASK_DARK;
 #else
-	float whichmask = fract(gl_FragCoord.x * -0.3333);
+	float whichmask = fract(floor(vTexCoord.x*params.OutputSize.x)*-0.3333));
 	float mask = 1.0 + float(whichmask <= 0.33333) * -MASK_DARK;
 #endif
 	vec3 colour = texture(Source, p).rgb;


### PR DESCRIPTION
Follow-up of https://github.com/libretro/RetroArch/pull/12816