### PR TITLE
SMAA: Fix color edge detection

### DIFF
--- a/anti-aliasing/shaders/smaa/SMAA.hlsl
+++ b/anti-aliasing/shaders/smaa/SMAA.hlsl
@@ -792,11 +792,11 @@ float2 SMAAColorEdgeDetectionPS(float2 texcoord,
 
     // Calculate left-left and top-top deltas:
     float3 Cleftleft  = SMAASamplePoint(colorTex, offset[2].xy).rgb;
-    t = abs(C - Cleftleft);
+    t = abs(Cleft - Cleftleft);
     delta.z = max(max(t.r, t.g), t.b);
 
     float3 Ctoptop = SMAASamplePoint(colorTex, offset[2].zw).rgb;
-    t = abs(C - Ctoptop);
+    t = abs(Ctop - Ctoptop);
     delta.w = max(max(t.r, t.g), t.b);
 
     // Calculate the final maximum delta:


### PR DESCRIPTION
SMAA: Fix color edge detection

Fix incorrect calculation of local contrast adaption in color edge detection

This is the fix from PR iryoku/smaa#11

I decided to port this fix as I was able in my tests to gather image evidence showing top/left edges that were obviously being missed by Color Edge Detection, that are fixed by the changes in this commit. Although the problem affects a lot of edges, it is rarely so obvious like in this image.

![Test evidence](https://github.com/jntesteves/slang-shaders/raw/feature/smaa-fix-evidence/anti-aliasing/shaders/smaa/test/smaa-fix-evidence.png)