### PR TITLE
Add border presets for GBA with AGB-001 and AGS-001 screen shaders

### DIFF
--- a/handheld/console-border/gba-agb001-color-motionblur-1x.slangp
+++ b/handheld/console-border/gba-agb001-color-motionblur-1x.slangp
@@ -1,0 +1,29 @@
+shaders = 4
+
+shader0 = ../../motionblur/shaders/response-time.slang
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = ../shaders/mgba/agb001.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 4.0
+
+shader2 = ../shaders/color/gba-color.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = shader-files/gb-pass-5.slang
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"

--- a/handheld/console-border/gba-agb001-color-motionblur-2x.slangp
+++ b/handheld/console-border/gba-agb001-color-motionblur-2x.slangp
@@ -1,0 +1,29 @@
+shaders = 4
+
+shader0 = ../../motionblur/shaders/response-time.slang
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = ../shaders/mgba/agb001.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 4.0
+
+shader2 = ../shaders/color/gba-color.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = shader-files/gb-pass-5.slang
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "2.0"
+OUT_X = "6400.0"
+OUT_Y = "3200.0"

--- a/handheld/console-border/gba-agb001-color-motionblur-3x.slangp
+++ b/handheld/console-border/gba-agb001-color-motionblur-3x.slangp
@@ -1,0 +1,29 @@
+shaders = 4
+
+shader0 = ../../motionblur/shaders/response-time.slang
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = ../shaders/mgba/agb001.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 4.0
+
+shader2 = ../shaders/color/gba-color.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = shader-files/gb-pass-5.slang
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "3.0"
+OUT_X = "9600.0"
+OUT_Y = "4800.0"

--- a/handheld/console-border/gba-ags001-color-motionblur-1x.slangp
+++ b/handheld/console-border/gba-ags001-color-motionblur-1x.slangp
@@ -1,0 +1,34 @@
+shaders = 5
+
+shader0 = ../../motionblur/shaders/response-time.slang
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = ../shaders/mgba/ags001.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 4.0
+
+shader2 = ../shaders/color/gba-color.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = ../shaders/mgba/ags001-light.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+
+shader4 = shader-files/gb-pass-5.slang
+filter_linear4 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"

--- a/handheld/console-border/gba-ags001-color-motionblur-2x.slangp
+++ b/handheld/console-border/gba-ags001-color-motionblur-2x.slangp
@@ -1,0 +1,34 @@
+shaders = 5
+
+shader0 = ../../motionblur/shaders/response-time.slang
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = ../shaders/mgba/ags001.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 4.0
+
+shader2 = ../shaders/color/gba-color.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = ../shaders/mgba/ags001-light.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+
+shader4 = shader-files/gb-pass-5.slang
+filter_linear4 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "2.0"
+OUT_X = "6400.0"
+OUT_Y = "3200.0"

--- a/handheld/console-border/gba-ags001-color-motionblur-3x.slangp
+++ b/handheld/console-border/gba-ags001-color-motionblur-3x.slangp
@@ -1,0 +1,34 @@
+shaders = 5
+
+shader0 = ../../motionblur/shaders/response-time.slang
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = ../shaders/mgba/ags001.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 4.0
+
+shader2 = ../shaders/color/gba-color.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = ../shaders/mgba/ags001-light.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+
+shader4 = shader-files/gb-pass-5.slang
+filter_linear4 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y"
+SCALE = "3.0"
+OUT_X = "9600.0"
+OUT_Y = "4800.0"


### PR DESCRIPTION
The AGB and AGS screen shaders always output 4x the base res (160p), so
1x is 640p, 2x is 1280p and 3x is 1920p.