### PR TITLE
zfast-crt: add preset for the coarse mask, suitable for HD displays

### DIFF
--- a/crt/shaders/zfast_crt/zfast_crt_coarsemask.slang
+++ b/crt/shaders/zfast_crt/zfast_crt_coarsemask.slang
@@ -1,0 +1,3 @@
+#version 450
+
+#include "zfast_crt_impl.inc"

--- a/crt/shaders/zfast_crt/zfast_crt_finemask.slang
+++ b/crt/shaders/zfast_crt/zfast_crt_finemask.slang
@@ -1,0 +1,8 @@
+#version 450
+
+// This can't be an option without slowing the shader down.
+// Note that only the fine mask works on SNES Classic Edition
+// due to Mali 400 gpu precision.
+#define FINEMASK
+
+#include "zfast_crt_impl.inc"

--- a/crt/shaders/zfast_crt/zfast_crt_impl.inc
+++ b/crt/shaders/zfast_crt/zfast_crt_impl.inc
@@ -1,5 +1,3 @@
-#version 450
-
 /*
     zfast_crt_standard - A simple, fast CRT shader.
 
@@ -52,10 +50,6 @@ layout(std140, set = 0, binding = 0) uniform UBO
 //#define FRAGMENT
 //#define VERTEX
 
-//This can't be an option without slowing the shader down
-//Comment this out for a coarser 3 pixel mask...which is currently broken
-//on SNES Classic Edition due to Mali 400 gpu precision
-#define FINEMASK
 //Some drivers don't return black with texture coordinates out of bounds
 //SNES Classic is too slow to black these areas out when using fullscreen
 //overlays.  But you can uncomment the below to black them out if necessary

--- a/crt/zfast-crt-hdmask.slangp
+++ b/crt/zfast-crt-hdmask.slangp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = shaders/zfast_crt/zfast_crt_coarsemask.slang
+filter_linear0 = true

--- a/crt/zfast-crt.slangp
+++ b/crt/zfast-crt.slangp
@@ -1,4 +1,4 @@
 shaders = 1
 
-shader0 = shaders/zfast_crt.slang
+shader0 = shaders/zfast_crt/zfast_crt_finemask.slang
 filter_linear0 = true


### PR DESCRIPTION
To avoid duplicating the whole shader implementation, the needed define
has been split into its own file, and the shader implementation is now
in an include file.