### PR TITLE
Use relative multiplier on NTSC Royale presets

### DIFF
--- a/presets/crt-royale-ntsc-composite.slangp
+++ b/presets/crt-royale-ntsc-composite.slangp
@@ -22,19 +22,16 @@ shaders = "14"
 shader0 = "../ntsc/shaders/ntsc-adaptive/ntsc-pass1.slang"
 shader1 = "../ntsc/shaders/ntsc-adaptive/ntsc-pass2.slang"
 
+scale_type0 = source
+scale_x0 = 4.0
 filter_linear0 = false
-filter_linear1 = false
-
-scale_type_x0 = absolute
-scale_type_y0 = source
-scale_x0 = 1024
 scale_y0 = 1.0
-frame_count_mod0 = 2
 float_framebuffer0 = true
 
 scale_type1 = source
 scale_x1 = 0.5
 scale_y1 = 1.0
+filter_linear1 = true
 
 # Set an identifier, filename, and sampling traits for the phosphor mask texture.
 # Load an aperture grille, slot mask, and an EDP shadow mask, and load a small

--- a/presets/crt-royale-ntsc-svideo.slangp
+++ b/presets/crt-royale-ntsc-svideo.slangp
@@ -22,19 +22,16 @@ shaders = "14"
 shader0 = "../ntsc/shaders/ntsc-adaptive/ntsc-pass1.slang"
 shader1 = "../ntsc/shaders/ntsc-adaptive/ntsc-pass2.slang"
 
+scale_type0 = source
+scale_x0 = 4.0
 filter_linear0 = false
-filter_linear1 = false
-
-scale_type_x0 = absolute
-scale_type_y0 = source
-scale_x0 = 1536
 scale_y0 = 1.0
-frame_count_mod0 = 2
 float_framebuffer0 = true
 
 scale_type1 = source
 scale_x1 = 0.5
 scale_y1 = 1.0
+filter_linear1 = true
 
 # Set an identifier, filename, and sampling traits for the phosphor mask texture.
 # Load an aperture grille, slot mask, and an EDP shadow mask, and load a small


### PR DESCRIPTION
The Royale NTSC presets were not using relative multipliers. This fixes that.