### PR TITLE
V2.6 Sony Megatron Shader

### DIFF
--- a/hdr/crt-sony-megatron-bang-olufsen-mx8000-hdr.slangp
+++ b/hdr/crt-sony-megatron-bang-olufsen-mx8000-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_crt_screen_type = "2.000000"
 hcrt_red_scanline_min = "0.650000"
 hcrt_red_scanline_max = "0.900000"

--- a/hdr/crt-sony-megatron-bang-olufsen-mx8000-sdr.slangp
+++ b/hdr/crt-sony-megatron-bang-olufsen-mx8000-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-bang-olufsen-mx8000-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-jvc-d-series-AV-36D501-hdr.slangp
+++ b/hdr/crt-sony-megatron-jvc-d-series-AV-36D501-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_crt_screen_type = "2.000000"
 hcrt_paper_white_nits = "700.000000"
 hcrt_brightness = "0.200000"

--- a/hdr/crt-sony-megatron-jvc-d-series-AV-36D501-sdr.slangp
+++ b/hdr/crt-sony-megatron-jvc-d-series-AV-36D501-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-jvc-d-series-AV-36D501-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-jvc-professional-TM-H1950CG-hdr.slangp
+++ b/hdr/crt-sony-megatron-jvc-professional-TM-H1950CG-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_paper_white_nits = "700.000000"
 hcrt_crt_screen_type = "1.000000"
 hcrt_crt_resolution = "2.000000"

--- a/hdr/crt-sony-megatron-jvc-professional-TM-H1950CG-sdr.slangp
+++ b/hdr/crt-sony-megatron-jvc-professional-TM-H1950CG-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-jvc-professional-TM-H1950CG-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp
+++ b/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_crt_screen_type = "2.000000"
 hcrt_paper_white_nits = "600.000000"
 hcrt_contrast = "0.000000"

--- a/hdr/crt-sony-megatron-sammy-atomiswave-sdr.slangp
+++ b/hdr/crt-sony-megatron-sammy-atomiswave-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-sammy-atomiswave-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sega-virtua-fighter-hdr.slangp
+++ b/hdr/crt-sony-megatron-sega-virtua-fighter-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_crt_screen_type = "2.000000"
 hcrt_paper_white_nits = "200.000000"
 hcrt_expand_gamut = "1.000000"

--- a/hdr/crt-sony-megatron-sega-virtua-fighter-sdr.slangp
+++ b/hdr/crt-sony-megatron-sega-virtua-fighter-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-sega-virtua-fighter-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sony-pvm-1910-hdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-1910-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_crt_resolution = "0.000000"
 hcrt_colour_system = "0.000000"
 hcrt_white_temperature = "2800.000000"

--- a/hdr/crt-sony-megatron-sony-pvm-1910-sdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-1910-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-sony-pvm-1910-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sony-pvm-20L4-hdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-20L4-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_brightness = "0.150000"
 hcrt_colour_system = "0.000000"
 hcrt_white_temperature = "2800.000000"

--- a/hdr/crt-sony-megatron-sony-pvm-20L4-sdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-20L4-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-sony-pvm-20L4-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sony-pvm-2730-hdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-2730-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_brightness = "0.150000"
 hcrt_colour_system = "0.000000"
 hcrt_white_temperature = "2800.000000"

--- a/hdr/crt-sony-megatron-sony-pvm-2730-sdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-2730-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-sony-pvm-2730-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-toshiba-microfilter-hdr.slangp
+++ b/hdr/crt-sony-megatron-toshiba-microfilter-hdr.slangp
@@ -1,3 +1,4 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_crt_screen_type = "1.000000"

--- a/hdr/crt-sony-megatron-toshiba-microfilter-sdr.slangp
+++ b/hdr/crt-sony-megatron-toshiba-microfilter-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-toshiba-microfilter-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-viewsonic-A90f+-hdr.slangp
+++ b/hdr/crt-sony-megatron-viewsonic-A90f+-hdr.slangp
@@ -1,5 +1,6 @@
 #reference "crt-sony-megatron.slangp"
 
+hcrt_hdr = "1.000000"
 hcrt_crt_screen_type = "1.000000"
 hcrt_crt_resolution = "2.000000"
 hcrt_paper_white_nits = "400.000000"

--- a/hdr/crt-sony-megatron-viewsonic-A90f+-sdr.slangp
+++ b/hdr/crt-sony-megatron-viewsonic-A90f+-sdr.slangp
@@ -1,0 +1,7 @@
+#reference "crt-sony-megatron-viewsonic-A90f+-hdr.slangp"
+
+hcrt_hdr = "0.000000"
+
+hcrt_brightness = "-0.200000"
+hcrt_contrast = "0.500000"
+hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron.slangp
+++ b/hdr/crt-sony-megatron.slangp
@@ -1,0 +1,54 @@
+/* 
+Sony Megatron Colour Video Monitor
+Author: Major Pain The Cactus
+
+A shader that specifically tries to emulate arcade monitor's with an shadow mask screen but with full brightness. 
+
+The novel thing about this shader is that it transforms the image output by the 'console/arcade/computer' into HDR space first i.e brightens it first and then applies 
+an shadow mask afterwards which is kind of what a CRT would actually do - its kind of a kin to the electron beam (but nothing like it lol). 
+
+My DisplayHDR 600 monitor does seem to get reasonably close to the brightness of my PVM - its not quite there but its close.  I think DisplayHDR 1000 and above will be able to match.
+
+To use:
+Please Enable HDR in RetroArch 1.10+
+[UPDATE] This shader supports SDR as well - just enable it in the shader parameters
+
+NOTE: when this shader is envoked the Contrast, Peak Luminance and Paper White Luminance in the HDR menu do nothing instead set those values through the shader parameters 
+
+For this shader set Paper White Luminance to above 700 and Peak Luminance to the peak luminance of your monitor.   
+
+Also try to use a integer scaling - its just better - overscaling is fine/great.
+
+This shader doesn't do any geometry warping or bouncing of light around inside the screen - I think these effects just add unwanted noise, I know people disagree. Please feel free to make you own and add them
+
+Works only with the D3D11/D3D12/Vulkan drivers currently
+
+DONT USE THIS PRESET DIRECTLY - Use any of the others in this directory
+*/
+
+shaders = "3"
+feedback_pass = "0"
+
+shader0 = "shaders/crt-sony-megatron-source-pass.slang"
+filter_linear0 = "false"
+scale_type0 = "source"
+scale0 = "1.0"
+wrap_mode0 = "clamp_to_border"
+mipmap_input0 = "false"
+alias0 = "SourceSDR"
+
+shader1 = "shaders/crt-sony-megatron-hdr-pass.slang"
+filter_linear1 = "false"
+scale_type1 = "source"
+scale1 = "1.0"
+wrap_mode1 = "clamp_to_border"
+mipmap_input1 = "false"
+alias1 = "SourceHDR"
+
+shader2 = "shaders/crt-sony-megatron.slang"
+filter_linear2 = "false"
+wrap_mode2 = "clamp_to_border"
+mipmap_input2 = "false"
+alias2 = ""
+float_framebuffer2 = "false"
+srgb_framebuffer2 = "false"

--- a/hdr/shaders/crt-sony-megatron-hdr-pass.slang
+++ b/hdr/shaders/crt-sony-megatron-hdr-pass.slang
@@ -70,7 +70,7 @@ layout(set = 0, binding = 2) uniform sampler2D Source;
 
 vec3 InverseTonemapConditional(const vec3 linear)
 {
-   if(HCRT_HDR > 0.0f)
+   if(HCRT_HDR < 1.0f)
    {
       return linear;
    }

--- a/hdr/shaders/crt-sony-megatron.slang
+++ b/hdr/shaders/crt-sony-megatron.slang
@@ -421,7 +421,7 @@ vec3 LinearToDCIP3(const vec3 colour)
 
 vec3 GammaCorrect(const vec3 scanline_colour)
 {
-   if(HCRT_HDR > 0.0f)
+   if(HCRT_HDR < 1.0f)
    {
       return HCRT_OUTPUT_COLOUR_SPACE == 0.0f ? LinearTosRGB(scanline_colour) : LinearToDCIP3(scanline_colour);
    }

--- a/hdr/shaders/include/parameters.h
+++ b/hdr/shaders/include/parameters.h
@@ -1,51 +1,53 @@
 
 
-#pragma parameter hcrt_title                         "SONY MEGATRON COLOUR VIDEO MONITOR"                        0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_space0                        " "                                                         0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_support0                      "Use as bright a display as possible but SDR is supported"  0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_space1                        " "                                                         0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_user_settings                 "USER SETTINGS:"                                            0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_hdr                           "    HDR | SDR"                                             0.0      0.0   1.0      1.0
-#pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                         700.0    0.0   10000.0  10.0
-#pragma parameter hcrt_paper_white_nits              "    HDR: Display's Paper White Luminance"                  700.0    0.0   10000.0  10.0
-#pragma parameter hcrt_colour_space                  "    SDR: Display's Colour Space: sRGB | DCI-P3"            0.0      0.0   1.0      1.0
-#pragma parameter hcrt_lcd_resolution                "    Display's Resolution: 4K | 8K"                         0.0      0.0   1.0      1.0
-#pragma parameter hcrt_lcd_subpixel                  "    Display's Subpixel Layout: RGB | BGR"                  0.0      0.0   1.0      1.0
-#pragma parameter hcrt_red_vertical_convergence      "    Red Vertical Convergence"                              0.00     -10.0 10.0     0.01
-#pragma parameter hcrt_green_vertical_convergence    "    Green Vertical Convergence"                            0.00     -10.0 10.0     0.01
-#pragma parameter hcrt_blue_vertical_convergence     "    Blue Vertical Convergence"                             0.00     -10.0 10.0     0.01
-#pragma parameter hcrt_red_horizontal_convergence    "    Red Horizontal Convergence"                            0.00     -10.0 10.0     0.01
-#pragma parameter hcrt_green_horizontal_convergence  "    Green Horizontal Convergence"                          0.00     -10.0 10.0     0.01
-#pragma parameter hcrt_blue_horizontal_convergence   "    Blue Horizontal Convergence"                           0.00     -10.0 10.0     0.01
+#pragma parameter hcrt_title                         "SONY MEGATRON COLOUR VIDEO MONITOR"                           0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_space0                        " "                                                            0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_support0                      "SDR mode: Turn up your TV's brightness as high as possible"   0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_support1                      "HDR mode: Set the peak luminance to that of your TV."         0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_support2                      "Then adjust paper white luminance until it looks right"       0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_space1                        " "                                                            0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_user_settings                 "USER SETTINGS:"                                               0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_hdr                           "    SDR | HDR"                                                1.0      0.0   1.0      1.0
+#pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                            700.0    0.0   10000.0  10.0
+#pragma parameter hcrt_paper_white_nits              "    HDR: Display's Paper White Luminance"                     700.0    0.0   10000.0  10.0
+#pragma parameter hcrt_colour_space                  "    SDR: Display's Colour Space: sRGB | DCI-P3"               0.0      0.0   1.0      1.0
+#pragma parameter hcrt_lcd_resolution                "    Display's Resolution: 4K | 8K"                            0.0      0.0   1.0      1.0
+#pragma parameter hcrt_lcd_subpixel                  "    Display's Subpixel Layout: RGB | BGR"                     0.0      0.0   1.0      1.0
+#pragma parameter hcrt_red_vertical_convergence      "    Red Vertical Convergence"                                 0.00     -10.0 10.0     0.01
+#pragma parameter hcrt_green_vertical_convergence    "    Green Vertical Convergence"                               0.00     -10.0 10.0     0.01
+#pragma parameter hcrt_blue_vertical_convergence     "    Blue Vertical Convergence"                                0.00     -10.0 10.0     0.01
+#pragma parameter hcrt_red_horizontal_convergence    "    Red Horizontal Convergence"                               0.00     -10.0 10.0     0.01
+#pragma parameter hcrt_green_horizontal_convergence  "    Green Horizontal Convergence"                             0.00     -10.0 10.0     0.01
+#pragma parameter hcrt_blue_horizontal_convergence   "    Blue Horizontal Convergence"                              0.00     -10.0 10.0     0.01
 
-#pragma parameter hcrt_space3                        " "                                                         0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_developer_settings            "DEVELOPER SETTINGS:"                                       0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_crt_screen_type               "    CRT Type: APERTURE GRILLE | SHADOW MASK | SLOT MASK"   0.0      0.0   3.0      1.0
-#pragma parameter hcrt_crt_resolution                "    CRT Resolution: 300TVL | 600TVL | 800TVL | 1000TVL"    1.0      0.0   3.0      1.0
-#pragma parameter hcrt_colour_system                 "    CRT Colour System: PAL | NTSC-U | NTSC-J"              1.0      0.0   2.0      1.0
-#pragma parameter hcrt_white_temperature             "    White Point: (PAL:D65, NTSC-U:D65, NTSC-J:D93)"        0.0      -5000.0  12000.0      100.0
-#pragma parameter hcrt_expand_gamut                  "    HDR: Original/Vivid"                                   0.0      0.0   1.0      1.0
-#pragma parameter hcrt_brightness                    "    Brightness"                                            0.0      -1.0  1.0      0.01
-#pragma parameter hcrt_contrast                      "    Contrast"                                              0.0      -1.0  1.0      0.01
-#pragma parameter hcrt_saturation                    "    Saturation"                                            0.0      -1.0   1.0     0.01
-#pragma parameter hcrt_gamma                         "    Gamma"                                                 0.0      -1.0   1.0     0.01
+#pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_developer_settings            "DEVELOPER SETTINGS:"                                          0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_crt_screen_type               "    CRT Type: APERTURE GRILLE | SHADOW MASK | SLOT MASK"      0.0      0.0   3.0      1.0
+#pragma parameter hcrt_crt_resolution                "    CRT Resolution: 300TVL | 600TVL | 800TVL | 1000TVL"       1.0      0.0   3.0      1.0
+#pragma parameter hcrt_colour_system                 "    CRT Colour System: PAL | NTSC-U | NTSC-J"                 1.0      0.0   2.0      1.0
+#pragma parameter hcrt_white_temperature             "    White Point: (PAL:D65, NTSC-U:D65, NTSC-J:D93)"           0.0      -5000.0  12000.0      100.0
+#pragma parameter hcrt_expand_gamut                  "    HDR: Original/Vivid"                                      0.0      0.0   1.0      1.0
+#pragma parameter hcrt_brightness                    "    Brightness"                                               0.0      -1.0  1.0      0.01
+#pragma parameter hcrt_contrast                      "    Contrast"                                                 0.0      -1.0  1.0      0.01
+#pragma parameter hcrt_saturation                    "    Saturation"                                               0.0      -1.0   1.0     0.01
+#pragma parameter hcrt_gamma                         "    Gamma"                                                    0.0      -1.0   1.0     0.01
 
-#pragma parameter hcrt_developer_settings0           "    VERTICAL SETTINGS:"                                    0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_red_scanline_min              "        Red Scanline Min"                                  0.50     0.0   2.0      0.01 
-#pragma parameter hcrt_red_scanline_max              "        Red Scanline Max"                                  1.00     0.0   2.0      0.01 
-#pragma parameter hcrt_red_scanline_attack           "        Red Scanline Attack"                               0.20     0.0   1.0      0.01
-#pragma parameter hcrt_green_scanline_min            "        Green Scanline Min"                                0.50     0.0   2.0      0.01 
-#pragma parameter hcrt_green_scanline_max            "        Green Scanline Max"                                1.00     0.0   2.0      0.01 
-#pragma parameter hcrt_green_scanline_attack         "        Green Scanline Attack"                             0.20     0.0   1.0      0.01
-#pragma parameter hcrt_blue_scanline_min             "        Blue Scanline Min"                                 0.50     0.0   2.0      0.01 
-#pragma parameter hcrt_blue_scanline_max             "        Blue Scanline Max"                                 1.00     0.0   2.0      0.01 
-#pragma parameter hcrt_blue_scanline_attack          "        Blue Scanline Attack"                              0.20     0.0   1.0      0.01
-#pragma parameter hcrt_developer_settings1           "    HORIZONTAL SETTINGS:"                                  0.0      0.0   0.0001   0.0
-#pragma parameter hcrt_red_beam_sharpness            "        Red Beam Sharpness"                                1.75     0.0   5.0      0.05
-#pragma parameter hcrt_red_beam_attack               "        Red Beam Attack"                                   0.50     0.0   2.0      0.01
-#pragma parameter hcrt_green_beam_sharpness          "        Green Beam Sharpness"                              1.75     0.0   5.0      0.05
-#pragma parameter hcrt_green_beam_attack             "        Green Beam Attack"                                 0.50     0.0   2.0      0.01
-#pragma parameter hcrt_blue_beam_sharpness           "        Blue Beam Sharpness"                               1.75     0.0   5.0      0.05
-#pragma parameter hcrt_blue_beam_attack              "        Blue Beam Attack"                                  0.50     0.0   2.0      0.01
+#pragma parameter hcrt_developer_settings0           "    VERTICAL SETTINGS:"                                       0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_red_scanline_min              "        Red Scanline Min"                                     0.50     0.0   2.0      0.01 
+#pragma parameter hcrt_red_scanline_max              "        Red Scanline Max"                                     1.00     0.0   2.0      0.01 
+#pragma parameter hcrt_red_scanline_attack           "        Red Scanline Attack"                                  0.20     0.0   1.0      0.01
+#pragma parameter hcrt_green_scanline_min            "        Green Scanline Min"                                   0.50     0.0   2.0      0.01 
+#pragma parameter hcrt_green_scanline_max            "        Green Scanline Max"                                   1.00     0.0   2.0      0.01 
+#pragma parameter hcrt_green_scanline_attack         "        Green Scanline Attack"                                0.20     0.0   1.0      0.01
+#pragma parameter hcrt_blue_scanline_min             "        Blue Scanline Min"                                    0.50     0.0   2.0      0.01 
+#pragma parameter hcrt_blue_scanline_max             "        Blue Scanline Max"                                    1.00     0.0   2.0      0.01 
+#pragma parameter hcrt_blue_scanline_attack          "        Blue Scanline Attack"                                 0.20     0.0   1.0      0.01
+#pragma parameter hcrt_developer_settings1           "    HORIZONTAL SETTINGS:"                                     0.0      0.0   0.0001   0.0
+#pragma parameter hcrt_red_beam_sharpness            "        Red Beam Sharpness"                                   1.75     0.0   5.0      0.05
+#pragma parameter hcrt_red_beam_attack               "        Red Beam Attack"                                      0.50     0.0   2.0      0.01
+#pragma parameter hcrt_green_beam_sharpness          "        Green Beam Sharpness"                                 1.75     0.0   5.0      0.05
+#pragma parameter hcrt_green_beam_attack             "        Green Beam Attack"                                    0.50     0.0   2.0      0.01
+#pragma parameter hcrt_blue_beam_sharpness           "        Blue Beam Sharpness"                                  1.75     0.0   5.0      0.05
+#pragma parameter hcrt_blue_beam_attack              "        Blue Beam Attack"                                     0.50     0.0   2.0      0.01
 
 


### PR DESCRIPTION
Fixed all the presets as I hadn't included crt-sont-megatron.slangp - oops! 
Added SDR versions of all the shader presets for ease of use 
Renamed original presets with hdr postfix 
Inverted HDR shader value so SDR is on 0 and HDR is on 1