### PR TITLE
V3.1 Sony Megatron Shader

### DIFF
--- a/hdr/crt-sony-megatron-bang-olufsen-mx8000-sdr.slangp
+++ b/hdr/crt-sony-megatron-bang-olufsen-mx8000-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-jvc-d-series-AV-36D501-sdr.slangp
+++ b/hdr/crt-sony-megatron-jvc-d-series-AV-36D501-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-jvc-professional-TM-H1950CG-sdr.slangp
+++ b/hdr/crt-sony-megatron-jvc-professional-TM-H1950CG-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sammy-atomiswave-sdr.slangp
+++ b/hdr/crt-sony-megatron-sammy-atomiswave-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sega-virtua-fighter-sdr.slangp
+++ b/hdr/crt-sony-megatron-sega-virtua-fighter-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sony-pvm-1910-sdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-1910-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sony-pvm-20L4-sdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-20L4-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-sony-pvm-2730-sdr.slangp
+++ b/hdr/crt-sony-megatron-sony-pvm-2730-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-toshiba-microfilter-sdr.slangp
+++ b/hdr/crt-sony-megatron-toshiba-microfilter-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.00000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/crt-sony-megatron-viewsonic-A90f+-sdr.slangp
+++ b/hdr/crt-sony-megatron-viewsonic-A90f+-sdr.slangp
@@ -2,6 +2,6 @@
 
 hcrt_hdr = "0.000000"
 
-hcrt_brightness = "-0.200000"
-hcrt_contrast = "0.500000"
+hcrt_brightness = "0.000000"
+hcrt_contrast = "0.000000"
 hcrt_gamma = "-0.600000"

--- a/hdr/shaders/include/colour_grade.h
+++ b/hdr/shaders/include/colour_grade.h
@@ -93,28 +93,30 @@ float r601r709ToLinear_1(const float channel)
 
 vec3 r601r709ToLinear(const vec3 colour)
 {
-	return vec3(r601r709ToLinear_1(colour.r), r601r709ToLinear_1(colour.g), r601r709ToLinear_1(colour.b));
+	//return vec3(r601r709ToLinear_1(colour.r), r601r709ToLinear_1(colour.g), r601r709ToLinear_1(colour.b));
+   return pow(colour, vec3((1.0f / 0.45f) + HCRT_GAMMA));
 }
 
-float LinearTor601r709_1(const float channel)
-{
-	return (channel >= 0.018f) ? pow(channel * 1.099f, 0.45f) - 0.099f : channel * 4.5f;
-}
+//float LinearTor601r709_1(const float channel)
+//{
+//	return (channel >= 0.018f) ? pow(channel * 1.099f, 0.45f) - 0.099f : channel * 4.5f;
+//}
 
-vec3 LinearTor601r709(const vec3 colour)
-{
-	return vec3(LinearTor601r709_1(colour.r), LinearTor601r709_1(colour.g), LinearTor601r709_1(colour.b));
-}
+//vec3 LinearTor601r709(const vec3 colour)
+//{
+//	return vec3(LinearTor601r709_1(colour.r), LinearTor601r709_1(colour.g), LinearTor601r709_1(colour.b));
+//}
 
 // SDR Colour output spaces
 float sRGBToLinear_1(const float channel)
 {
-	return (channel > 0.04045f) ? pow((channel + 0.055f) * (1.0f / 1.055f), 2.4f + HCRT_GAMMA) : channel * (1.0f / 12.92f);
+	return (channel > 0.04045f) ? pow((channel + 0.055f) * (1.0f / 1.055f), 2.4f) : channel * (1.0f / 12.92f);
 }
 
 vec3 sRGBToLinear(const vec3 colour)
 {
-	return vec3(sRGBToLinear_1(colour.r), sRGBToLinear_1(colour.g), sRGBToLinear_1(colour.b));
+	//return vec3(sRGBToLinear_1(colour.r), sRGBToLinear_1(colour.g), sRGBToLinear_1(colour.b));
+   return pow(colour, vec3(2.4f));
 }
 
 float LinearTosRGB_1(const float channel)
@@ -124,7 +126,8 @@ float LinearTosRGB_1(const float channel)
 
 vec3 LinearTosRGB(const vec3 colour)
 {
-	return vec3(LinearTosRGB_1(colour.r), LinearTosRGB_1(colour.g), LinearTosRGB_1(colour.b));
+	//return vec3(LinearTosRGB_1(colour.r), LinearTosRGB_1(colour.g), LinearTosRGB_1(colour.b));
+   return pow(colour, vec3(1.0f / 2.4f));
 }
 
 vec3 LinearToDCIP3(const vec3 colour)
@@ -215,11 +218,11 @@ vec3 ColourGrade(const vec3 colour)
 
    const vec3 linear          = r601r709ToLinear(colour);
 
-   const vec3 graded          = BrightnessContrastSaturation(linear); 
-
-   const vec3 gamut           = (HCRT_HDR == 0.0f) && (HCRT_OUTPUT_COLOUR_SPACE == 0.0f) ? graded : kPhosphorGamut[colour_system] * graded;
+   const vec3 gamut           = linear; // (HCRT_HDR == 0.0f) && (HCRT_OUTPUT_COLOUR_SPACE == 0.0f) ? linear : kPhosphorGamut[colour_system] * linear;
 
    const vec3 white_point     = WhiteBalance(kTemperatures[colour_system] + HCRT_WHITE_TEMPERATURE, gamut);
 
-   return clamp(XYZ_to_sRGB * white_point, 0.0f, 1.0f);
+   const vec3 graded          = BrightnessContrastSaturation(white_point); 
+
+   return graded;
 }

--- a/hdr/shaders/include/gamma_correct.h
+++ b/hdr/shaders/include/gamma_correct.h
@@ -1,13 +1,4 @@
 // SDR Colour output spaces
-float sRGBToLinear_1(const float channel)
-{
-	return (channel > 0.04045f) ? pow((channel + 0.055f) * (1.0f / 1.055f), 2.4f + HCRT_GAMMA) : channel * (1.0f / 12.92f);
-}
-
-vec3 sRGBToLinear(const vec3 colour)
-{
-	return vec3(sRGBToLinear_1(colour.r), sRGBToLinear_1(colour.g), sRGBToLinear_1(colour.b));
-}
 
 float LinearTosRGB_1(const float channel)
 {

--- a/hdr/shaders/include/parameters.h
+++ b/hdr/shaders/include/parameters.h
@@ -6,7 +6,7 @@
 #pragma parameter hcrt_support1                      "HDR mode: Set the peak luminance to that of your TV."         0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_support2                      "Then adjust paper white luminance until it looks right"       0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_space1                        " "                                                            0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_user_settings                 "YOUR DISPLAY SETTINGS:"                                       0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_user_settings                 "YOUR DISPLAY'S SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_hdr                           "    SDR | HDR"                                                1.0      0.0   1.0      1.0
 #pragma parameter hcrt_colour_space                  "    SDR: Display's Colour Space: sRGB | DCI-P3"               0.0      0.0   1.0      1.0
 #pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                            700.0    0.0   10000.0  10.0


### PR DESCRIPTION
Fixed colour issues when skipping phosphor gamuts 
Fixed gamma curves cropping dark colours (as per spec but not wanted early on in colour correction) 
Fixed up SDR presets to have zero values for main colour controls apart from gamma which is moved up to try and compensate for the dimmness