### PR TITLE
Fixed Magic Bloom capitalization error

### DIFF
--- a/reshade/magicbloom.slangp
+++ b/reshade/magicbloom.slangp
@@ -95,4 +95,4 @@ scale11 = 1.0
 
 textures = "tMagicBloom_Dirt"
 
-tMagicBloom_Dirt = "./shaders/magicbloom/MagicBloom_dirt.png"
+tMagicBloom_Dirt = "./shaders/magicbloom/MagicBloom_Dirt.png"


### PR DESCRIPTION
Capitalization mismatch on one of the texture files, seems like it might fail on Linux or Android even though it's fine on windows