### PR TITLE
V3.6 Sony Megatron Shader

### DIFF
--- a/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp
+++ b/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp
@@ -1,8 +1,12 @@
 #reference "shaders/crt-sony-megatron-hdr.slangp"
 
 hcrt_crt_screen_type = "2.000000"
-hcrt_paper_white_nits = "600.000000"
+hcrt_colour_system = "3.000000"
+hcrt_paper_white_nits = "700.000000"
 hcrt_contrast = "0.000000"
+hcrt_brightness = "0.050000"
+hcrt_saturation = "0.450000"
+hcrt_gamma_in = "2.220000"
 hcrt_expand_gamut = "1.000000"
 hcrt_red_scanline_min = "0.8900000"
 hcrt_red_scanline_max = "1.000000"

--- a/hdr/crt-sony-megatron-sammy-atomiswave-sdr.slangp
+++ b/hdr/crt-sony-megatron-sammy-atomiswave-sdr.slangp
@@ -1,8 +1,10 @@
 #reference "shaders/crt-sony-megatron-sdr.slangp"
 
 hcrt_crt_screen_type = "2.000000"
-hcrt_paper_white_nits = "600.000000"
+hcrt_colour_system = "3.000000"
 hcrt_contrast = "0.000000"
+hcrt_brightness = "0.050000"
+hcrt_saturation = "0.450000"
 hcrt_red_scanline_min = "0.8900000"
 hcrt_red_scanline_max = "1.000000"
 hcrt_red_scanline_attack = "0.300000"

--- a/hdr/shaders/crt-sony-megatron.slang
+++ b/hdr/shaders/crt-sony-megatron.slang
@@ -375,7 +375,7 @@ const uint kApertureGrilleMasks8K600TVL[kBGRAxis][kMaxApertureGrilleSize] =
 
 const uint kApertureGrilleMasks8K800TVL[kBGRAxis][kMaxApertureGrilleSize] = 
 { 
-   kRYCBX, kRMCGX, kRYCBX
+   kRYCBX, kRMCGX, kBCYRX
 };
 
 #undef kMaxApertureGrilleSize 

--- a/hdr/shaders/include/parameters.h
+++ b/hdr/shaders/include/parameters.h
@@ -14,6 +14,7 @@
 #pragma parameter hcrt_user_settings                 "YOUR DISPLAY'S SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_hdr                           "    SDR | HDR"                                                1.0      0.0   1.0      1.0
 #pragma parameter hcrt_colour_space                  "    SDR: Display's Colour Space: r709 | sRGB | DCI-P3"        1.0      0.0   2.0      1.0
+#pragma parameter hcrt_gamma_out                     "    SDR: Gamma"                                               2.4      1.0   5.0      0.01
 #pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                            700.0    0.0   10000.0  10.0
 #pragma parameter hcrt_paper_white_nits              "    HDR: Display's Paper White Luminance"                     700.0    0.0   10000.0  10.0
 #pragma parameter hcrt_expand_gamut                  "    HDR: Original/Vivid"                                      0.0      0.0   1.0      1.0
@@ -29,8 +30,7 @@
 #pragma parameter hcrt_brightness                    "    Brightness"                                               0.0     -1.0   1.0      0.01
 #pragma parameter hcrt_contrast                      "    Contrast"                                                 0.0     -1.0   1.0      0.01
 #pragma parameter hcrt_saturation                    "    Saturation"                                               0.0     -1.0   1.0      0.01
-#pragma parameter hcrt_gamma_in                      "    Gamma In"                                                 2.4      1.0   5.0      0.01
-#pragma parameter hcrt_gamma_out                     "    Gamma Out"                                                2.4      1.0   5.0      0.01
+#pragma parameter hcrt_gamma_in                      "    Gamma"                                                    2.4      1.0   5.0      0.01
 #pragma parameter hcrt_pin_phase                     "    Pin Phase"                                                0.00    -0.2   0.2      0.01
 #pragma parameter hcrt_pin_amp                       "    Pin Amp"                                                  0.00    -0.2   0.2      0.01
 #pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0001


### PR DESCRIPTION
Fixed 800TVL BGR aperture grille mask 
Recalibrated the sammy atomiswave preset that now takes advantage of the high precision gamma 
Reorganised the gamma parameters to be a bit more intuitive than gamma in/out - doesn't effect presets