### PR TITLE
V4.1 Sony Megatron Shader

### DIFF
--- a/hdr/shaders/crt-sony-megatron-hdr-pass.slang
+++ b/hdr/shaders/crt-sony-megatron-hdr-pass.slang
@@ -33,6 +33,7 @@ layout(push_constant) uniform Push
    float hcrt_max_nits;
    float hcrt_paper_white_nits;
    float hcrt_expand_gamut;
+   float hcrt_colour_accurate;
 } params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
@@ -50,6 +51,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_MAX_NITS                       params.hcrt_max_nits
 #define HCRT_PAPER_WHITE_NITS               params.hcrt_paper_white_nits
 #define HCRT_EXPAND_GAMUT                   params.hcrt_expand_gamut
+#define HCRT_COLOUR_ACCURATE                params.hcrt_colour_accurate
 
 #define COMPAT_TEXTURE(c, d) texture(c, d)
 
@@ -92,14 +94,14 @@ void main()
 
    vec3 transformed_colour;
 
-   if(HCRT_HDR < 1.0f)
-   {      
-      transformed_colour = hdr_colour;
-   }
-   else
+   if((HCRT_HDR >= 1.0f) && (HCRT_COLOUR_ACCURATE < 1.0f))
    {
       const vec3 rec2020  = hdr_colour * k2020Gamuts[uint(HCRT_EXPAND_GAMUT)];
       transformed_colour  = rec2020 * (HCRT_PAPER_WHITE_NITS / kMaxNitsFor2084);
+   }
+   else
+   {      
+      transformed_colour = hdr_colour;
    }
 
    FragColor = vec4(transformed_colour, 1.0);

--- a/hdr/shaders/crt-sony-megatron-source-pass.slang
+++ b/hdr/shaders/crt-sony-megatron-source-pass.slang
@@ -40,6 +40,7 @@ layout(push_constant) uniform Push
    float hcrt_contrast;
    float hcrt_saturation;
    float hcrt_gamma_in;
+   float hcrt_colour_accurate;
 } params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
@@ -61,6 +62,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_CONTRAST                       params.hcrt_contrast
 #define HCRT_SATURATION                     params.hcrt_saturation
 #define HCRT_GAMMA_IN                       params.hcrt_gamma_in
+#define HCRT_COLOUR_ACCURATE                params.hcrt_colour_accurate
 
 #define COMPAT_TEXTURE(c, d) texture(c, d)
 
@@ -90,7 +92,7 @@ void main()
 
    vec3 transformed_colour;
 
-   if(HCRT_HDR < 1.0f)
+   if((HCRT_HDR < 1.0f) && (HCRT_COLOUR_ACCURATE < 1.0f))
    {
       if(HCRT_OUTPUT_COLOUR_SPACE == 2.0f)
       {

--- a/hdr/shaders/crt-sony-megatron.slang
+++ b/hdr/shaders/crt-sony-megatron.slang
@@ -36,6 +36,7 @@ layout(push_constant) uniform Push
    float hcrt_paper_white_nits;
    float hcrt_expand_gamut;
    float hcrt_gamma_out;
+   float hcrt_colour_accurate;
 
    float hcrt_lcd_resolution;
    float hcrt_lcd_subpixel;
@@ -96,6 +97,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_PAPER_WHITE_NITS                params.hcrt_paper_white_nits
 #define HCRT_EXPAND_GAMUT                    params.hcrt_expand_gamut
 #define HCRT_GAMMA_OUT                       params.hcrt_gamma_out
+#define HCRT_COLOUR_ACCURATE                 params.hcrt_colour_accurate
 
 #define HCRT_LCD_RESOLUTION                  params.hcrt_lcd_resolution 
 #define HCRT_LCD_SUBPIXEL                    params.hcrt_lcd_subpixel
@@ -1634,9 +1636,32 @@ void main()
       scanline_colour += scanline_channel_2 * kColourMask[channel_2];
    }
 
+   vec3 transformed_colour;
+
+   if(HCRT_COLOUR_ACCURATE >= 1.0f)
+   {
+      if(HCRT_HDR >= 1.0f)
+      {
+         const vec3 rec2020  = scanline_colour * k2020Gamuts[uint(HCRT_EXPAND_GAMUT)];
+         transformed_colour  = rec2020 * (HCRT_PAPER_WHITE_NITS / kMaxNitsFor2084);
+      }
+      else if(HCRT_OUTPUT_COLOUR_SPACE == 2.0f)
+      {
+         transformed_colour = (scanline_colour * k709_to_XYZ) * kXYZ_to_DCIP3; 
+      }
+      else
+      {
+         transformed_colour = scanline_colour;
+      }
+   } 
+   else
+   {      
+      transformed_colour = scanline_colour;
+   }
+
    vec3 gamma_corrected; 
    
-   GammaCorrect(scanline_colour, gamma_corrected);
+   GammaCorrect(transformed_colour, gamma_corrected);
 
    FragColor = vec4(gamma_corrected, 1.0f);
 }

--- a/hdr/shaders/include/parameters.h
+++ b/hdr/shaders/include/parameters.h
@@ -13,6 +13,7 @@
 #pragma parameter hcrt_space1                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_user_settings                 "YOUR DISPLAY'S SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_hdr                           "    SDR | HDR"                                                1.0      0.0   1.0      1.0
+#pragma parameter hcrt_colour_accurate               "    Mask Accurate/Colour Accurate"                            1.0      0.0   1.0      1.0
 #pragma parameter hcrt_colour_space                  "    SDR: Display's Colour Space: r709 | sRGB | DCI-P3"        1.0      0.0   2.0      1.0
 #pragma parameter hcrt_gamma_out                     "    SDR: Gamma"                                               2.4      1.0   5.0      0.01
 #pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                            700.0    0.0   10000.0  10.0


### PR DESCRIPTION
Added mask accurate/colour accurate switch which effects HDR and DCI-P3 to parameters so that users can choose whether they want 100% pitch black mask or more correct looking colours i.e. not so yellow-y looking greens. Defaults to latter which is the original behaviour.