### PR TITLE
 V4.1 Sony Megatron Shader - Presets

### DIFF
--- a/hdr/crt-sony-megatron-default-hdr.slangp
+++ b/hdr/crt-sony-megatron-default-hdr.slangp
@@ -1,3 +1,3 @@
-#reference ":/shaders/shaders_slang/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp"
+#reference "crt-sony-megatron-sammy-atomiswave-hdr.slangp"
 hcrt_colour_accurate = "0.000000"
 hcrt_crt_screen_type = "0.000000"

--- a/hdr/crt-sony-megatron-default-hdr.slangp
+++ b/hdr/crt-sony-megatron-default-hdr.slangp
@@ -1,0 +1,3 @@
+#reference ":/shaders/shaders_slang/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp"
+hcrt_colour_accurate = "0.000000"
+hcrt_crt_screen_type = "0.000000"

--- a/hdr/crt-sony-megatron-gba-gbi-hdr.slangp
+++ b/hdr/crt-sony-megatron-gba-gbi-hdr.slangp
@@ -1,4 +1,4 @@
-#reference "shaders_slang/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp"
+#reference "crt-sony-megatron-sammy-atomiswave-hdr.slangp"
 hcrt_colour_accurate = "0.000000"
 hcrt_crt_screen_type = "0.000000"
 hcrt_crt_resolution = "0.000000"

--- a/hdr/crt-sony-megatron-gba-gbi-hdr.slangp
+++ b/hdr/crt-sony-megatron-gba-gbi-hdr.slangp
@@ -1,0 +1,4 @@
+#reference "shaders_slang/hdr/crt-sony-megatron-sammy-atomiswave-hdr.slangp"
+hcrt_colour_accurate = "0.000000"
+hcrt_crt_screen_type = "0.000000"
+hcrt_crt_resolution = "0.000000"


### PR DESCRIPTION
Added two new presets - one is what I regard a good default for HDR the other is for an emulation of GBA and the GBI on a CRT.