### PR TITLE
V4.1 Sony Megatron Shader - Presets

### DIFF
--- a/hdr/crt-sony-megatron-default-hdr.slangp
+++ b/hdr/crt-sony-megatron-default-hdr.slangp
@@ -1,3 +1,2 @@
 #reference "crt-sony-megatron-sammy-atomiswave-hdr.slangp"
-hcrt_colour_accurate = "0.000000"
 hcrt_crt_screen_type = "0.000000"

--- a/hdr/crt-sony-megatron-gba-gbi-hdr.slangp
+++ b/hdr/crt-sony-megatron-gba-gbi-hdr.slangp
@@ -1,4 +1,3 @@
 #reference "crt-sony-megatron-sammy-atomiswave-hdr.slangp"
-hcrt_colour_accurate = "0.000000"
 hcrt_crt_screen_type = "0.000000"
 hcrt_crt_resolution = "0.000000"


### PR DESCRIPTION
Made colour accurate the default setting for the 'default' and 'gba-gbi' presets