### PR TITLE
Add sgenpt-mix-multipass shaders

### DIFF
--- a/dithering/sgenpt-mix-multipass.slangp
+++ b/dithering/sgenpt-mix-multipass.slangp
@@ -1,0 +1,33 @@
+shaders = 6
+
+shader0 = shaders/sgenpt-mix/linearize.slang
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+alias0 = LinearGamma
+
+shader1 = shaders/sgenpt-mix/sgenpt-mix-pass1.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 1.0
+
+shader2 = shaders/sgenpt-mix/sgenpt-mix-pass2.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+
+shader3 = shaders/sgenpt-mix/sgenpt-mix-pass3.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+alias3 = CB_Output
+
+shader4 = shaders/sgenpt-mix/sgenpt-mix-pass4.slang
+filter_linear4 = false
+scale_type4 = source
+scale4 = 1.0
+
+
+shader5 = shaders/sgenpt-mix/sgenpt-mix-pass5.slang
+filter_linear5 = false
+

--- a/dithering/shaders/sgenpt-mix/linearize.slang
+++ b/dithering/shaders/sgenpt-mix/linearize.slang
@@ -1,0 +1,45 @@
+#version 450
+
+layout(push_constant) uniform Push
+{
+	vec4 SourceSize;
+	vec4 OriginalSize;
+	vec4 OutputSize;
+	uint FrameCount;
+	float SGPT_BLEND_OPTION;
+	float UseGamma;
+} params;
+
+#pragma parameter SGPT_BLEND_OPTION    "SGENPT-MIX: [ OFF | CB | VL | BOTH ]" 3.0  0.0 3.0  1.0
+#pragma parameter UseGamma           "    Gamma Slider"                       1.0  0.0 1.0  0.1
+
+#define UseGamma     params.UseGamma
+#define LinInputGamma   (UseGamma+1.0)
+
+#define GAMMA_IN(color)     pow(color, vec3(LinInputGamma, LinInputGamma, LinInputGamma))
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+	mat4 MVP;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+void main()
+{
+   FragColor = vec4(GAMMA_IN(texture(Source, vTexCoord).rgb), 1.0);
+}

--- a/dithering/shaders/sgenpt-mix/sgenpt-mix-pass1.slang
+++ b/dithering/shaders/sgenpt-mix/sgenpt-mix-pass1.slang
@@ -1,0 +1,107 @@
+#version 450
+
+/*
+   Sgenpt-Mix - pass1
+   
+   2011-2022 Hyllian - sergiogdb@gmail.com
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is 
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+*/
+
+
+layout(push_constant) uniform Push
+{
+    vec4 SourceSize;
+    vec4 OriginalSize;
+    vec4 OutputSize;
+    uint FrameCount;
+    float SGPT_BLEND_OPTION;
+    float CB_BLEND_LEVEL;
+} params;
+
+#pragma parameter SGPT_BLEND_OPTION    "SGENPT-MIX: [ OFF | CB | VL | BOTH ]" 3.0  0.0 3.0  1.0
+#pragma parameter CB_BLEND_LEVEL     "    Checkerboard Blend Level"                     1.0  0.0 1.0  0.1
+
+#define SGPT_BLEND_OPTION             params.SGPT_BLEND_OPTION
+#define CB_BLEND_LEVEL              params.CB_BLEND_LEVEL
+
+const vec3 Y = vec3( 0.299,  0.587,  0.114);
+
+vec3 min_s(vec3 central, vec3 adj1, vec3 adj2) {return min(central, max(adj1, adj2));}
+vec3 max_s(vec3 central, vec3 adj1, vec3 adj2) {return max(central, min(adj1, adj2));}
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+void main()
+{
+    vec2 dx = vec2(1.0, 0.0)*params.SourceSize.zw;
+    vec2 dy = vec2(0.0, 1.0)*params.SourceSize.zw;
+
+    // Reading the texels.
+    vec3 C  = texture(Source, vTexCoord    ).xyz;
+    vec3 L  = texture(Source, vTexCoord -dx).xyz;
+    vec3 R  = texture(Source, vTexCoord +dx).xyz;
+    vec3 U  = texture(Source, vTexCoord -dy).xyz;
+    vec3 D  = texture(Source, vTexCoord +dy).xyz;
+    vec3 UL = texture(Source, vTexCoord -dx -dy).xyz;
+    vec3 UR = texture(Source, vTexCoord +dx -dy).xyz;
+    vec3 DL = texture(Source, vTexCoord -dx +dy).xyz;
+    vec3 DR = texture(Source, vTexCoord +dx +dy).xyz;
+
+    vec3 color = C;
+
+    if (SGPT_BLEND_OPTION == 1 || SGPT_BLEND_OPTION == 3)
+    {
+        float diff = dot(max(C, max(L, R)) - min(C, min(L, R)), Y);
+
+        diff *= (1.0 - CB_BLEND_LEVEL);
+
+        vec3 min_sample = max(min_s(C, L, R), min_s(C, U, D));
+        vec3 max_sample = min(max_s(C, L, R), max_s(C, U, D));
+
+        color = 0.5*( 1.0 + diff )*C + 0.125*( 1.0 - diff )*(L + R + U + D);
+
+        color = clamp(color, min_sample, max_sample);
+    }
+
+    float luma_diff = abs(dot(C, Y)-dot(color, Y));
+
+    FragColor = vec4(color, luma_diff);
+}

--- a/dithering/shaders/sgenpt-mix/sgenpt-mix-pass2.slang
+++ b/dithering/shaders/sgenpt-mix/sgenpt-mix-pass2.slang
@@ -1,0 +1,142 @@
+#version 450
+
+/*
+   Sgenpt-Mix - pass2
+   
+   2011-2022 Hyllian - sergiogdb@gmail.com
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is 
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+*/
+
+
+layout(push_constant) uniform Push
+{
+    vec4 SourceSize;
+    vec4 OriginalSize;
+    vec4 OutputSize;
+    uint FrameCount;
+    float CB_BLEND_LEVEL;
+} params;
+
+#pragma parameter CB_BLEND_LEVEL               "    Checkerboard Blend Level"                     1.0  0.0 1.0  0.1
+
+#define CB_BLEND_LEVEL             params.CB_BLEND_LEVEL
+
+#define PATTERN(A)                 step(Delta,A)
+
+const float Delta = 0.000000001;
+const vec3 Y = vec3( 0.299,  0.587,  0.114);
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D LinearGamma;
+
+void main()
+{
+    vec2 dx = vec2(1.0, 0.0)*params.SourceSize.zw;
+    vec2 dy = vec2(0.0, 1.0)*params.SourceSize.zw;
+
+    // Reading the texels.
+    vec4 C =  texture(Source, vTexCoord        );
+    vec4 L =  texture(Source, vTexCoord -dx    );
+    vec4 R =  texture(Source, vTexCoord +dx    );
+    vec4 U =  texture(Source, vTexCoord     -dy);
+    vec4 D =  texture(Source, vTexCoord     +dy);
+    vec4 UL = texture(Source, vTexCoord -dx -dy);
+    vec4 UR = texture(Source, vTexCoord +dx -dy);
+    vec4 DL = texture(Source, vTexCoord -dx +dy);
+    vec4 DR = texture(Source, vTexCoord +dx +dy);
+
+    vec4 L2 =  texture(Source, vTexCoord -2.0*dx    );
+    vec4 R2 =  texture(Source, vTexCoord +2.0*dx    );
+    vec4 U2 =  texture(Source, vTexCoord     -2.0*dy);
+    vec4 D2 =  texture(Source, vTexCoord     +2.0*dy);
+
+    vec4 UL2 =  texture(Source, vTexCoord -2.0*dx -dy);
+    vec4 UR2 =  texture(Source, vTexCoord +2.0*dx -dy);
+    vec4 DL2 =  texture(Source, vTexCoord -2.0*dx +dy);
+    vec4 DR2 =  texture(Source, vTexCoord +2.0*dx +dy);
+
+    vec4 LU2 =  texture(Source, vTexCoord -dx -2.0*dy);
+    vec4 RU2 =  texture(Source, vTexCoord +dx -2.0*dy);
+    vec4 LD2 =  texture(Source, vTexCoord -dx +2.0*dy);
+    vec4 RD2 =  texture(Source, vTexCoord +dx -2.0*dy);
+
+    vec3 color =  C.rgb;
+
+    vec3 oriC = texture(LinearGamma, vTexCoord        ).rgb;
+    vec3 oriL = texture(LinearGamma, vTexCoord -dx    ).rgb;
+    vec3 oriR = texture(LinearGamma, vTexCoord +dx    ).rgb;
+    vec3 oriU = texture(LinearGamma, vTexCoord     -dy).rgb;
+    vec3 oriD = texture(LinearGamma, vTexCoord     +dy).rgb;
+
+    float count1 = 0.0;
+    float count2 = 0.0;
+
+    float diff  = (1.0 - CB_BLEND_LEVEL);
+
+//      LU2  U2  RU2
+//  UL2  UL   U  UR  UR2
+//   L2   L   C   R   R2
+//  DL2  DL   D  DR  DR2
+//      LD2  D2  RD2
+
+    count1 += PATTERN(L.a*D.a*R.a);
+    count1 += PATTERN(L.a*U.a*R.a);
+    count1 += PATTERN(L.a*UL.a*R.a*UR.a + L.a*DL.a*R.a*DR.a);
+
+    count1 += PATTERN(U.a*D2.a*(UL.a*LD2.a + UR.a*RD2.a) + U2.a*D.a*(LU2.a*DL.a + RU2.a*DR.a));
+
+    count2 += PATTERN(U.a*L.a*D.a);
+    count2 += PATTERN(U.a*R.a*D.a);
+    count2 += PATTERN(U.a*UR.a*D.a*DR.a + D.a*DL.a*U.a*UL.a);
+
+    count2 += PATTERN(L.a*R2.a*(DL.a*DR2.a + UL.a*UR2.a) + L2.a*R.a*(DL2.a*DR.a + UL2.a*UR.a));
+
+    if ((count1 * count2) > 0.0 && count1 == count2)
+        color = 0.5*(1.0+diff)*oriC + 0.125*(1.0-diff)*(oriL + oriR + oriU + oriD);
+    else if (count1 > 0.0 && count1 > count2)
+        color = 0.5*(1.0+diff)*oriC + 0.25*(1.0-diff)*(oriL + oriR);
+    else if (count2 > 0.0 && count2 > count1)
+        color = 0.5*(1.0+diff)*oriC + 0.25*(1.0-diff)*(oriU + oriD);
+
+    float luma_diff = abs(dot(oriC, Y)-dot(color, Y));
+
+    FragColor = vec4(color, luma_diff);
+}

--- a/dithering/shaders/sgenpt-mix/sgenpt-mix-pass3.slang
+++ b/dithering/shaders/sgenpt-mix/sgenpt-mix-pass3.slang
@@ -1,0 +1,152 @@
+#version 450
+
+/*
+   Sgenpt-Mix - pass3
+   
+   2011-2022 Hyllian - sergiogdb@gmail.com
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is 
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+*/
+
+
+layout(push_constant) uniform Push
+{
+    vec4 SourceSize;
+    vec4 OriginalSize;
+    vec4 OutputSize;
+    uint FrameCount;
+    float CB_MITIG_NEIGHBRS;
+    float CB_MITIG_LINES;
+    float CB_ADJUST_VIEW;
+    float UseGamma;
+} params;
+
+#pragma parameter CB_MITIG_NEIGHBRS            "        CB - Mitigate Errors (neighbors)" 1.0  0.0 4.0  1.0
+#pragma parameter CB_MITIG_LINES               "        CB - Mitigate Errors (regions)"   1.0  0.0 1.0  1.0
+#pragma parameter CB_ADJUST_VIEW               "        CB - Adjust View"                 0.0  0.0 1.0  1.0
+#pragma parameter UseGamma                     "    Gamma Slider"                1.0  0.0 1.0  0.1
+
+#define CB_MITIG_NEIGHBRS   params.CB_MITIG_NEIGHBRS
+#define CB_MITIG_LINES      params.CB_MITIG_LINES
+#define CB_ADJUST_VIEW      params.CB_ADJUST_VIEW
+#define UseGamma            params.UseGamma
+#define CBDOuputGamma          (UseGamma+1.0)
+
+#define GAMMA_OUT(color)    pow(color, vec3(1.0 / CBDOuputGamma, 1.0 / CBDOuputGamma, 1.0 / CBDOuputGamma))
+
+#define PATTERN(A)          step(Delta,A)
+
+const float Delta = 0.000000001;
+const vec3 Y = vec3( 0.299,  0.587,  0.114);
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D LinearGamma;
+
+void main()
+{
+    vec2 dx = vec2(1.0, 0.0)*params.SourceSize.zw;
+    vec2 dy = vec2(0.0, 1.0)*params.SourceSize.zw;
+
+    // Reading the texels.
+    vec4 C =  texture(Source, vTexCoord        );
+    vec4 L =  texture(Source, vTexCoord -dx    );
+    vec4 R =  texture(Source, vTexCoord +dx    );
+    vec4 U =  texture(Source, vTexCoord     -dy);
+    vec4 D =  texture(Source, vTexCoord     +dy);
+    vec4 UL = texture(Source, vTexCoord -dx -dy);
+    vec4 UR = texture(Source, vTexCoord +dx -dy);
+    vec4 DL = texture(Source, vTexCoord -dx +dy);
+    vec4 DR = texture(Source, vTexCoord +dx +dy);
+
+    vec4 L2 =  texture(Source, vTexCoord -2.0*dx    );
+    vec4 R2 =  texture(Source, vTexCoord +2.0*dx    );
+    vec4 U2 =  texture(Source, vTexCoord     -2.0*dy);
+    vec4 D2 =  texture(Source, vTexCoord     +2.0*dy);
+
+    vec4 L3 =  texture(Source, vTexCoord -3.0*dx    );
+    vec4 R3 =  texture(Source, vTexCoord +3.0*dx    );
+    vec4 U3 =  texture(Source, vTexCoord     -3.0*dy);
+    vec4 D3 =  texture(Source, vTexCoord     +3.0*dy);
+
+    vec3 color =  C.rgb;
+
+    vec3 oriC = texture(LinearGamma, vTexCoord        ).rgb;
+
+    float count   = 0.0;
+    float count2  = 0.0;
+    float count3  = 0.0;
+
+//              U3
+//              U2     
+//          UL   U  UR     
+//  L3  L2   L   C   R   R2  R3
+//          DL   D  DR     
+//              D2     
+//              D3
+
+    count += PATTERN(L.a);
+    count += PATTERN(R.a);
+    count += PATTERN(U.a);
+    count += PATTERN(D.a);
+    count += PATTERN(UL.a*UR.a*DL.a*DR.a);
+
+    count2 += PATTERN(L.a*UL.a*U.a + U.a*UR.a*R.a + R.a*DR.a*D.a + D.a*DL.a*L.a);
+
+    count3 += PATTERN(L3.a*L2.a*L.a);
+    count3 += PATTERN(L2.a*L.a*R.a);
+    count3 += PATTERN(L.a*R.a*R2.a);
+    count3 += PATTERN(R.a*R2.a*R3.a);
+
+    count3 += PATTERN(U3.a*U2.a*U.a);
+    count3 += PATTERN(U2.a*U.a*D.a);
+    count3 += PATTERN(U.a*D.a*D2.a);
+    count3 += PATTERN(D.a*D2.a*D3.a);
+
+    if ((count < CB_MITIG_NEIGHBRS)  && (count2 < 1.0))
+        color = oriC;
+    else if ((CB_MITIG_LINES == 1.0) && (count3 < 1.0))
+        color = oriC;
+
+    float luma_diff = abs(dot(oriC, Y)-dot(color, Y));
+
+    color = mix(color, vec3(luma_diff), CB_ADJUST_VIEW);
+
+    FragColor = vec4(color, 1.0);
+}

--- a/dithering/shaders/sgenpt-mix/sgenpt-mix-pass4.slang
+++ b/dithering/shaders/sgenpt-mix/sgenpt-mix-pass4.slang
@@ -1,0 +1,107 @@
+#version 450
+
+/*
+   Sgenpt-Mix - pass4
+   
+   2011-2022 Hyllian - sergiogdb@gmail.com
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is 
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+*/
+
+
+layout(push_constant) uniform Push
+{
+    vec4 SourceSize;
+    vec4 OriginalSize;
+    vec4 OutputSize;
+    uint FrameCount;
+    float SGPT_BLEND_OPTION;
+    float VL_BLEND_LEVEL;
+} params;
+
+#pragma parameter SGPT_BLEND_OPTION    "SGENPT-MIX: [ OFF | CB | VL | BOTH ]"               3.0  0.0 3.0  1.0
+#pragma parameter VL_BLEND_LEVEL       "    Vertical Lines Blend Level"                     0.8  0.0 1.0  0.1
+
+#define SGPT_BLEND_OPTION             params.SGPT_BLEND_OPTION
+#define VL_BLEND_LEVEL                params.VL_BLEND_LEVEL
+
+const vec3 Y = vec3( 0.299,  0.587,  0.114);
+
+vec3 min_s(vec3 central, vec3 adj1, vec3 adj2) {return min(central, max(adj1, adj2));}
+vec3 max_s(vec3 central, vec3 adj1, vec3 adj2) {return max(central, min(adj1, adj2));}
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+void main()
+{
+    vec2 dx = vec2(1.0, 0.0)*params.SourceSize.zw;
+    vec2 dy = vec2(0.0, 1.0)*params.SourceSize.zw;
+
+    // Reading the texels.
+    vec3 C  = texture(Source, vTexCoord    ).xyz;
+    vec3 L  = texture(Source, vTexCoord -dx).xyz;
+    vec3 R  = texture(Source, vTexCoord +dx).xyz;
+    vec3 U  = texture(Source, vTexCoord -dy).xyz;
+    vec3 D  = texture(Source, vTexCoord +dy).xyz;
+    vec3 UL = texture(Source, vTexCoord -dx -dy).xyz;
+    vec3 UR = texture(Source, vTexCoord +dx -dy).xyz;
+    vec3 DL = texture(Source, vTexCoord -dx +dy).xyz;
+    vec3 DR = texture(Source, vTexCoord +dx +dy).xyz;
+
+    vec3 color = C;
+
+    if (SGPT_BLEND_OPTION == 2 || SGPT_BLEND_OPTION == 3)
+    {
+        float diff = dot(max(C, max(L, R)) - min(C, min(L, R)), Y);
+
+        diff *= (1.0 - VL_BLEND_LEVEL);
+
+        vec3 min_sample = max_s(min_s(C, L, R), min_s(C, DL, DR), min_s(C, UL, UR));
+        vec3 max_sample = min_s(max_s(C, L, R), max_s(C, DL, DR), max_s(C, UL, UR));
+
+        color = 0.5*( 1.0 + diff )*C + 0.25*( 1.0 - diff )*(L + R);
+
+        color = clamp(color, min_sample, max_sample);
+    }
+
+    float luma_diff = abs(dot(C, Y)-dot(color, Y));
+
+    FragColor = vec4(color, luma_diff);
+}

--- a/dithering/shaders/sgenpt-mix/sgenpt-mix-pass5.slang
+++ b/dithering/shaders/sgenpt-mix/sgenpt-mix-pass5.slang
@@ -1,0 +1,152 @@
+#version 450
+
+/*
+   Sgenpt-Mix - pass5
+   
+   2011-2022 Hyllian - sergiogdb@gmail.com
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is 
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+*/
+
+
+layout(push_constant) uniform Push
+{
+    vec4 SourceSize;
+    vec4 OriginalSize;
+    vec4 OutputSize;
+    uint FrameCount;
+    float VL_MITIG_NEIGHBRS;
+    float VL_MITIG_LINES;
+    float VL_ADJUST_VIEW;
+    float UseGamma;
+} params;
+
+#pragma parameter VL_MITIG_NEIGHBRS            "        VL - Mitigate Errors (neighbors)" 1.0  0.0 4.0  1.0
+#pragma parameter VL_MITIG_LINES               "        VL - Mitigate Errors (regions)"   1.0  0.0 1.0  1.0
+#pragma parameter VL_ADJUST_VIEW               "        VL - Adjust View"                 0.0  0.0 1.0  1.0
+#pragma parameter UseGamma                     "    Gamma Slider"                     1.0  0.0 1.0  0.1
+
+#define VL_MITIG_NEIGHBRS   params.VL_MITIG_NEIGHBRS
+#define VL_MITIG_LINES      params.VL_MITIG_LINES
+#define VL_ADJUST_VIEW      params.VL_ADJUST_VIEW
+#define UseGamma            params.UseGamma
+#define CBDOuputGamma          (UseGamma+1.0)
+
+#define GAMMA_OUT(color)    pow(color, vec3(1.0 / CBDOuputGamma, 1.0 / CBDOuputGamma, 1.0 / CBDOuputGamma))
+
+#define PATTERN(A)          step(Delta,A)
+
+const float Delta = 0.000000001;
+const vec3 Y = vec3( 0.299,  0.587,  0.114);
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D CB_Output;
+
+void main()
+{
+    vec2 dx = vec2(1.0, 0.0)*params.SourceSize.zw;
+    vec2 dy = vec2(0.0, 1.0)*params.SourceSize.zw;
+
+    // Reading the texels.
+    vec4 C =  texture(Source, vTexCoord        );
+    vec4 L =  texture(Source, vTexCoord -dx    );
+    vec4 R =  texture(Source, vTexCoord +dx    );
+    vec4 U =  texture(Source, vTexCoord     -dy);
+    vec4 D =  texture(Source, vTexCoord     +dy);
+    vec4 UL = texture(Source, vTexCoord -dx -dy);
+    vec4 UR = texture(Source, vTexCoord +dx -dy);
+    vec4 DL = texture(Source, vTexCoord -dx +dy);
+    vec4 DR = texture(Source, vTexCoord +dx +dy);
+
+    vec4 L2 =  texture(Source, vTexCoord -2.0*dx    );
+    vec4 R2 =  texture(Source, vTexCoord +2.0*dx    );
+    vec4 U2 =  texture(Source, vTexCoord     -2.0*dy);
+    vec4 D2 =  texture(Source, vTexCoord     +2.0*dy);
+
+    vec4 L3 =  texture(Source, vTexCoord -3.0*dx    );
+    vec4 R3 =  texture(Source, vTexCoord +3.0*dx    );
+    vec4 U3 =  texture(Source, vTexCoord     -3.0*dy);
+    vec4 D3 =  texture(Source, vTexCoord     +3.0*dy);
+
+    vec3 color =  C.rgb;
+
+    vec3 oriC = texture(CB_Output, vTexCoord        ).rgb;
+
+    float count   = 0.0;
+    float count2  = 0.0;
+    float count3  = 0.0;
+    float count4  = 0.0;
+
+//              U3
+//              U2     
+//          UL   U  UR     
+//  L3  L2   L   C   R   R2  R3
+//          DL   D  DR     
+//              D2     
+//              D3
+
+    count += PATTERN(L.a);
+    count += PATTERN(R.a);
+    count += PATTERN(U.a);
+    count += PATTERN(D.a);
+
+    count += PATTERN(UL.a*UR.a*DL.a*DR.a);
+
+    count2 += PATTERN(L.a*UL.a*U.a + U.a*UR.a*R.a + R.a*DR.a*D.a + D.a*DL.a*L.a);
+
+    count3 += PATTERN(L3.a*L2.a*L.a);
+    count3 += PATTERN(L2.a*L.a*R.a);
+    count3 += PATTERN(L.a*R.a*R2.a);
+    count3 += PATTERN(R.a*R2.a*R3.a);
+
+    count4 += PATTERN(U.a);
+    count4 += PATTERN(D.a);
+
+    if ((count < VL_MITIG_NEIGHBRS)  && (count2 < 1.0))
+        color = oriC;
+    else if ((VL_MITIG_LINES == 1.0) && ((count3*count4) < 1.0))
+        color = oriC;
+
+    float luma_diff = abs(dot(oriC, Y)-dot(color, Y));
+
+    color = mix(color, vec3(luma_diff), VL_ADJUST_VIEW);
+
+    FragColor = vec4(GAMMA_OUT(color), 1.0);
+}


### PR DESCRIPTION
- Checkerboard treatment on par with checkerboar-dedither shaders (it’ll indeed be incorporated eventually);
- Vertical Lines dedither improved, less false positives (though a bit of false negative);
- CB and VL independent options.