### PR TITLE
V4.4 Sony Megatron Shader

### DIFF
--- a/hdr/shaders/include/colour_grade.h
+++ b/hdr/shaders/include/colour_grade.h
@@ -74,7 +74,8 @@ vec3 WhiteBalance(float temperature, vec3 colour)
 float r601ToLinear_1(const float channel)
 {
 	//return (channel >= 0.081f) ? pow((channel + 0.099f) * (1.0f / 1.099f), (1.0f / 0.45f)) : channel * (1.0f / 4.5f);
-	return (channel >= 0.081f) ? pow((channel + 0.099f) * (1.0f / 1.099f), HCRT_GAMMA_IN) : channel * (1.0f / 4.5f);
+	//return (channel >= 0.081f) ? pow((channel + 0.099f) * (1.0f / 1.099f), HCRT_GAMMA_IN) : channel * (1.0f / 4.5f);
+   return pow((channel + 0.099f) * (1.0f / 1.099f), HCRT_GAMMA_IN);
 }
 
 vec3 r601ToLinear(const vec3 colour)
@@ -86,7 +87,8 @@ vec3 r601ToLinear(const vec3 colour)
 float r709ToLinear_1(const float channel)
 {
 	//return (channel >= 0.081f) ? pow((channel + 0.099f) * (1.0f / 1.099f), (1.0f / 0.45f)) : channel * (1.0f / 4.5f);
-	return (channel >= 0.081f) ? pow((channel + 0.099f) * (1.0f / 1.099f), HCRT_GAMMA_IN) : channel * (1.0f / 4.5f);
+	//return (channel >= 0.081f) ? pow((channel + 0.099f) * (1.0f / 1.099f), HCRT_GAMMA_IN) : channel * (1.0f / 4.5f);
+   return pow((channel + 0.099f) * (1.0f / 1.099f), HCRT_GAMMA_IN);
 }
 
 vec3 r709ToLinear(const vec3 colour)

--- a/hdr/shaders/include/gamma_correct.h
+++ b/hdr/shaders/include/gamma_correct.h
@@ -14,7 +14,8 @@ const mat3 kXYZ_to_DCIP3 = mat3 (
 
 float LinearTosRGB_1(const float channel)
 {
-	return (channel > 0.0031308f) ? (1.055f * pow(channel, 1.0f / HCRT_GAMMA_OUT)) - 0.055f : channel * 12.92f; 
+	//return (channel > 0.0031308f) ? (1.055f * pow(channel, 1.0f / HCRT_GAMMA_OUT)) - 0.055f : channel * 12.92f; 
+   return (1.055f * pow(channel, 1.0f / HCRT_GAMMA_OUT)) - 0.055f; 
 }
 
 vec3 LinearTosRGB(const vec3 colour)
@@ -24,7 +25,8 @@ vec3 LinearTosRGB(const vec3 colour)
 
 float LinearTo709_1(const float channel)
 {
-	return (channel >= 0.018f) ? pow(channel * 1.099f, 1.0f / (HCRT_GAMMA_OUT - 0.18f)) - 0.099f : channel * 4.5f;  // Gamma: 2.4 - 0.18 = 2.22
+	//return (channel >= 0.018f) ? pow(channel * 1.099f, 1.0f / (HCRT_GAMMA_OUT - 0.18f)) - 0.099f : channel * 4.5f;  // Gamma: 2.4 - 0.18 = 2.22
+   return pow(channel * 1.099f, 1.0f / (HCRT_GAMMA_OUT - 0.18f)) - 0.099f;
 }
 
 vec3 LinearTo709(const vec3 colour)


### PR DESCRIPTION
Removed gamma guards as they were corrupting the image as you went to the extremes of gamma - this is not what the various standard's do.  I will revisit this once I figure out why they are needed and why they are corrupting the image for now they are out.