### PR TITLE
V4.5 Sony Megatron Shader

### DIFF
--- a/hdr/shaders/crt-sony-megatron.slang
+++ b/hdr/shaders/crt-sony-megatron.slang
@@ -190,10 +190,10 @@ const vec3 kColourMask[3] = { kRedChannel, kGreenChannel, kBlueChannel };
 
 // APERTURE GRILLE MASKS
 
-const float kApertureGrilleMaskSize[kResolutionAxis][kTVLAxis] = { 
-   { 4.0f, 2.0f, 1.0f, 1.0f },      // 1080p:   300 TVL, 600 TVL, 800 TVL, 1000 TVL 
-   { 7.0f, 4.0f, 3.0f, 2.0f },      // 4K:      300 TVL, 600 TVL, 800 TVL, 1000 TVL   
-   { 13.0f, 7.0f, 5.0f, 4.0f } };   // 8K:      300 TVL, 600 TVL, 800 TVL, 1000 TVL
+const float kApertureGrilleMaskSize[kResolutionAxis * kTVLAxis] = { 
+     4.0f, 2.0f, 1.0f, 1.0f ,      // 1080p:   300 TVL, 600 TVL, 800 TVL, 1000 TVL 
+     7.0f, 4.0f, 3.0f, 2.0f ,      // 4K:      300 TVL, 600 TVL, 800 TVL, 1000 TVL   
+    13.0f, 7.0f, 5.0f, 4.0f   };   // 8K:      300 TVL, 600 TVL, 800 TVL, 1000 TVL
 
 
 // 1080p 
@@ -201,11 +201,11 @@ const float kApertureGrilleMaskSize[kResolutionAxis][kTVLAxis] = {
 // 300TVL
 #define kMaxApertureGrilleSize       4
 
-#define kRGBX           { kRed, kGreen, kBlue, kBlack }
-#define kRBGX           { kRed, kBlue, kGreen, kBlack }
-#define kBGRX           { kBlue, kGreen, kRed, kBlack }
+#define kRGBX             kRed, kGreen, kBlue, kBlack  
+#define kRBGX             kRed, kBlue, kGreen, kBlack  
+#define kBGRX             kBlue, kGreen, kRed, kBlack  
 
-const uint kApertureGrilleMasks1080p300TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks1080p300TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 {
    kRGBX, kRBGX, kBGRX
 };
@@ -219,11 +219,11 @@ const uint kApertureGrilleMasks1080p300TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 600TVL
 #define kMaxApertureGrilleSize       2
 
-#define kMG             { kMagenta, kGreen }
-#define kYB             { kYellow, kBlue }
-#define kGM             { kGreen, kMagenta }
+#define kMG               kMagenta, kGreen  
+#define kYB               kYellow, kBlue  
+#define kGM               kGreen, kMagenta  
 
-const uint kApertureGrilleMasks1080p600TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks1080p600TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 {
    kMG, kYB, kGM
 };
@@ -237,15 +237,15 @@ const uint kApertureGrilleMasks1080p600TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 800TVL
 #define kMaxApertureGrilleSize       1
 
-#define kW              { kWhite }
+#define kW                kWhite  
 
-const uint kApertureGrilleMasks1080p800TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks1080p800TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 {
    kW, kW, kW
 };
 
 // 1000TVL
-const uint kApertureGrilleMasks1080p1000TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks1080p1000TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 {
    kW, kW, kW
 };
@@ -260,11 +260,11 @@ const uint kApertureGrilleMasks1080p1000TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 300TVL
 #define kMaxApertureGrilleSize       7
 
-#define kRRGGBBX        { kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack }
-#define kRRBBGGX        { kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack }
-#define kBBGGRRX        { kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack }
+#define kRRGGBBX          kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack  
+#define kRRBBGGX          kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack  
+#define kBBGGRRX          kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack  
 
-const uint kApertureGrilleMasks4K300TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks4K300TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kRRGGBBX, kRRBBGGX, kBBGGRRX
 };
@@ -278,11 +278,11 @@ const uint kApertureGrilleMasks4K300TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 600TVL
 #define kMaxApertureGrilleSize       4
 
-#define kRGBX           { kRed, kGreen, kBlue, kBlack }
-#define kRBGX           { kRed, kBlue, kGreen, kBlack }
-#define kBGRX           { kBlue, kGreen, kRed, kBlack }
+#define kRGBX             kRed, kGreen, kBlue, kBlack  
+#define kRBGX             kRed, kBlue, kGreen, kBlack  
+#define kBGRX             kBlue, kGreen, kRed, kBlack  
 
-const uint kApertureGrilleMasks4K600TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks4K600TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kRGBX, kRBGX, kBGRX 
 };
@@ -296,11 +296,11 @@ const uint kApertureGrilleMasks4K600TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 800TVL
 #define kMaxApertureGrilleSize       3
 
-#define kRGB            { kRed, kGreen, kBlue }
-#define kGBR            { kGreen, kBlue, kRed }
-#define kBGR            { kBlue, kGreen, kRed }
+#define kRGB              kRed, kGreen, kBlue  
+#define kGBR              kGreen, kBlue, kRed  
+#define kBGR              kBlue, kGreen, kRed  
 
-const uint kApertureGrilleMasks4K800TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks4K800TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kBGR, kGBR, kRGB 
 };
@@ -314,11 +314,11 @@ const uint kApertureGrilleMasks4K800TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 1000TVL
 #define kMaxApertureGrilleSize       2
 
-#define kMG             { kMagenta, kGreen }
-#define kYB             { kYellow, kBlue }
-#define kGM             { kGreen, kMagenta }
+#define kMG               kMagenta, kGreen  
+#define kYB               kYellow, kBlue  
+#define kGM               kGreen, kMagenta  
 
-const uint kApertureGrilleMasks4K1000TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks4K1000TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kMG, kYB, kGM
 };
@@ -335,11 +335,11 @@ const uint kApertureGrilleMasks4K1000TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 300 TVL
 #define kMaxApertureGrilleSize       13
 
-#define kRRRRGGGGBBBBX  { kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kBlack }
-#define kRRRRBBBBGGGGX  { kRed, kRed, kRed, kRed, kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kBlack }
-#define kBBBBGGGGRRRRX  { kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kRed, kRed, kRed, kRed, kBlack }
+#define kRRRRGGGGBBBBX    kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kBlack  
+#define kRRRRBBBBGGGGX    kRed, kRed, kRed, kRed, kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kBlack  
+#define kBBBBGGGGRRRRX    kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kRed, kRed, kRed, kRed, kBlack  
 
-const uint kApertureGrilleMasks8K300TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks8K300TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kRRRRGGGGBBBBX, kRRRRBBBBGGGGX, kBBBBGGGGRRRRX
 };
@@ -353,11 +353,11 @@ const uint kApertureGrilleMasks8K300TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 600 TVL
 #define kMaxApertureGrilleSize       7
 
-#define kRRGGBBX        { kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack }
-#define kRRBBGGX        { kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack }
-#define kBBGGRRX        { kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack }
+#define kRRGGBBX          kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack  
+#define kRRBBGGX          kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack  
+#define kBBGGRRX          kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack  
 
-const uint kApertureGrilleMasks8K600TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks8K600TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kRRGGBBX, kRRBBGGX, kBBGGRRX 
 };
@@ -371,11 +371,11 @@ const uint kApertureGrilleMasks8K600TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 800 TVL
 #define kMaxApertureGrilleSize       5
 
-#define kRYCBX          { kRed, kYellow, kCyan, kBlue, kBlack }
-#define kRMCGX          { kRed, kMagenta, kCyan, kGreen, kBlack }
-#define kBCYRX          { kBlue, kCyan, kYellow, kRed, kBlack }
+#define kRYCBX            kRed, kYellow, kCyan, kBlue, kBlack  
+#define kRMCGX            kRed, kMagenta, kCyan, kGreen, kBlack  
+#define kBCYRX            kBlue, kCyan, kYellow, kRed, kBlack  
 
-const uint kApertureGrilleMasks8K800TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks8K800TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kRYCBX, kRMCGX, kBCYRX
 };
@@ -389,11 +389,11 @@ const uint kApertureGrilleMasks8K800TVL[kBGRAxis][kMaxApertureGrilleSize] =
 // 1000 TVL
 #define kMaxApertureGrilleSize       4
 
-#define kRGBX           { kRed, kGreen, kBlue, kBlack }
-#define kRBGX           { kRed, kBlue, kGreen, kBlack }
-#define kBGRX           { kBlue, kGreen, kRed, kBlack }
+#define kRGBX             kRed, kGreen, kBlue, kBlack  
+#define kRBGX             kRed, kBlue, kGreen, kBlack  
+#define kBGRX             kBlue, kGreen, kRed, kBlack  
 
-const uint kApertureGrilleMasks8K1000TVL[kBGRAxis][kMaxApertureGrilleSize] = 
+const uint kApertureGrilleMasks8K1000TVL[kBGRAxis * kMaxApertureGrilleSize] = 
 { 
    kRGBX, kRBGX, kBGRX 
 };
@@ -407,33 +407,33 @@ const uint kApertureGrilleMasks8K1000TVL[kBGRAxis][kMaxApertureGrilleSize] =
 
 // SHADOW MASKS
 
-const float kShadowMaskSizeX[kResolutionAxis][kTVLAxis] = { { 6.0f, 2.0f, 1.0f, 1.0f }, { 12.0f, 6.0f, 2.0f, 2.0f }, { 12.0f, 12.0f, 6.0f, 6.0f } }; 
-const float kShadowMaskSizeY[kResolutionAxis][kTVLAxis] = { { 4.0f, 2.0f, 1.0f, 1.0f }, {  8.0f, 4.0f, 2.0f, 2.0f }, {  8.0f,  8.0f, 4.0f, 4.0f } }; 
+const float kShadowMaskSizeX[kResolutionAxis * kTVLAxis] = {   6.0f, 2.0f, 1.0f, 1.0f  ,   12.0f, 6.0f, 2.0f, 2.0f  ,   12.0f, 12.0f, 6.0f, 6.0f   }; 
+const float kShadowMaskSizeY[kResolutionAxis * kTVLAxis] = {   4.0f, 2.0f, 1.0f, 1.0f  ,    8.0f, 4.0f, 2.0f, 2.0f  ,    8.0f,  8.0f, 4.0f, 4.0f   }; 
 
 
 // 1080p 
 
 
-#define kXXXX              { kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
+#define kXXXX                kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
 
 // 300 TVL
 #define kMaxShadowMaskSizeX     6
 #define kMaxShadowMaskSizeY     4
 
-#define kGRRBBG            { kGreen, kRed, kRed, kBlue, kBlue, kGreen }
-#define kBBGGRR            { kBlue, kBlue, kGreen, kGreen, kRed, kRed }
+#define kGRRBBG              kGreen, kRed, kRed, kBlue, kBlue, kGreen  
+#define kBBGGRR              kBlue, kBlue, kGreen, kGreen, kRed, kRed  
 
-#define kBRRGGB            { kBlue, kRed, kRed, kGreen, kGreen, kBlue }
-#define kGGBBRR            { kGreen, kGreen, kBlue, kBlue, kRed, kRed }
+#define kBRRGGB              kBlue, kRed, kRed, kGreen, kGreen, kBlue  
+#define kGGBBRR              kGreen, kGreen, kBlue, kBlue, kRed, kRed  
 
-#define kGBBRRG            { kGreen, kBlue, kBlue, kRed, kRed, kGreen }
-#define kRRGGBB            { kRed, kRed, kGreen, kGreen, kBlue, kBlue }
+#define kGBBRRG              kGreen, kBlue, kBlue, kRed, kRed, kGreen  
+#define kRRGGBB              kRed, kRed, kGreen, kGreen, kBlue, kBlue  
 
-#define kGRRBBG_GRRBBG_BBGGRR_BBGGRR  { kGRRBBG, kGRRBBG, kBBGGRR, kBBGGRR }
-#define kBRRGGB_BRRGGB_GGBBRR_GGBBRR  { kBRRGGB, kBRRGGB, kGGBBRR, kGGBBRR }
-#define kGBBRRG_GBBRRG_RRGGBB_RRGGBB  { kGBBRRG, kGBBRRG, kRRGGBB, kRRGGBB }
+#define kGRRBBG_GRRBBG_BBGGRR_BBGGRR    kGRRBBG, kGRRBBG, kBBGGRR, kBBGGRR  
+#define kBRRGGB_BRRGGB_GGBBRR_GGBBRR    kBRRGGB, kBRRGGB, kGGBBRR, kGGBBRR  
+#define kGBBRRG_GBBRRG_RRGGBB_RRGGBB    kGBBRRG, kGBBRRG, kRRGGBB, kRRGGBB  
 
-const uint kShadowMasks1080p300TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks1080p300TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kGRRBBG_GRRBBG_BBGGRR_BBGGRR, kBRRGGB_BRRGGB_GGBBRR_GGBBRR, kGBBRRG_GBBRRG_RRGGBB_RRGGBB        // 300 TVL
 };
@@ -459,17 +459,17 @@ const uint kShadowMasks1080p300TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMask
 #define kMaxShadowMaskSizeX     2
 #define kMaxShadowMaskSizeY     2
 
-#define kMG                { kMagenta, kGreen }
-#define kGM                { kGreen, kMagenta }
+#define kMG                  kMagenta, kGreen  
+#define kGM                  kGreen, kMagenta  
 
-#define kYB                { kYellow, kBlue }
-#define kBY                { kBlue, kYellow }
+#define kYB                  kYellow, kBlue  
+#define kBY                  kBlue, kYellow  
 
-#define kMG_GM             { kMG, kGM }
-#define kYB_BY             { kYB, kBY }
-#define kGM_MG             { kGM, kMG }
+#define kMG_GM               kMG, kGM  
+#define kYB_BY               kYB, kBY  
+#define kGM_MG               kGM, kMG  
 
-const uint kShadowMasks1080p600TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks1080p600TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kMG_GM, kYB_BY, kGM_MG                                                                          // 600 TVL
 };
@@ -491,16 +491,16 @@ const uint kShadowMasks1080p600TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMask
 #define kMaxShadowMaskSizeX     1
 #define kMaxShadowMaskSizeY     1
 
-#define kW                 { kWhite }
-#define kW_W               { kW }
+#define kW                   kWhite  
+#define kW_W                 kW  
 
-const uint kShadowMasks1080p800TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks1080p800TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kW_W, kW_W, kW_W                                                                                // 800 TVL
 };
 
 // 1000 TVL
-const uint kShadowMasks1080p1000TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks1080p1000TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kW_W, kW_W, kW_W                                                                                // 1000 TVL
 };
@@ -519,20 +519,20 @@ const uint kShadowMasks1080p1000TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMas
 #define kMaxShadowMaskSizeX     12
 #define kMaxShadowMaskSizeY     8
 
-#define kGGRRRRBBBBGG      { kGreen, kGreen, kRed, kRed, kRed, kRed, kBlue, kBlue, kBlue, kBlue, kGreen, kGreen }
-#define kBBBBGGGGRRRR      { kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kRed, kRed, kRed, kRed }
+#define kGGRRRRBBBBGG        kGreen, kGreen, kRed, kRed, kRed, kRed, kBlue, kBlue, kBlue, kBlue, kGreen, kGreen  
+#define kBBBBGGGGRRRR        kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kRed, kRed, kRed, kRed  
 
-#define kBBRRRRGGGGBB      { kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue }
-#define kGGGGBBBBRRRR      { kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed }
+#define kBBRRRRGGGGBB        kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue  
+#define kGGGGBBBBRRRR        kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed  
 
-#define kGGBBBBRRRRGG      { kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen }
-#define kRRRRGGGGBBBB      { kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue }
+#define kGGBBBBRRRRGG        kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen  
+#define kRRRRGGGGBBBB        kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue  
 
-#define kGGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR  { kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR }
-#define kBBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR  { kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR }
-#define kGGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB  { kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB }
+#define kGGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR    kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR  
+#define kBBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR    kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR  
+#define kGGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB    kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB  
 
-const uint kShadowMasks4K300TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks4K300TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kGGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR, 
    kBBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR,
@@ -561,20 +561,20 @@ const uint kShadowMasks4K300TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSiz
 #define kMaxShadowMaskSizeX     6
 #define kMaxShadowMaskSizeY     4
 
-#define kGRRBBG            { kGreen, kRed, kRed, kBlue, kBlue, kGreen }
-#define kBBGGRR            { kBlue, kBlue, kGreen, kGreen, kRed, kRed }
+#define kGRRBBG              kGreen, kRed, kRed, kBlue, kBlue, kGreen  
+#define kBBGGRR              kBlue, kBlue, kGreen, kGreen, kRed, kRed  
 
-#define kBRRGGB            { kBlue, kRed, kRed, kGreen, kGreen, kBlue }
-#define kGGBBRR            { kGreen, kGreen, kBlue, kBlue, kRed, kRed }
+#define kBRRGGB              kBlue, kRed, kRed, kGreen, kGreen, kBlue  
+#define kGGBBRR              kGreen, kGreen, kBlue, kBlue, kRed, kRed  
 
-#define kGBBRRG            { kGreen, kBlue, kBlue, kRed, kRed, kGreen }
-#define kRRGGBB            { kRed, kRed, kGreen, kGreen, kBlue, kBlue }
+#define kGBBRRG              kGreen, kBlue, kBlue, kRed, kRed, kGreen  
+#define kRRGGBB              kRed, kRed, kGreen, kGreen, kBlue, kBlue  
 
-#define kGRRBBG_GRRBBG_BBGGRR_BBGGRR  { kGRRBBG, kGRRBBG, kBBGGRR, kBBGGRR }
-#define kBRRGGB_BRRGGB_GGBBRR_GGBBRR  { kBRRGGB, kBRRGGB, kGGBBRR, kGGBBRR }
-#define kGBBRRG_GBBRRG_RRGGBB_RRGGBB  { kGBBRRG, kGBBRRG, kRRGGBB, kRRGGBB }
+#define kGRRBBG_GRRBBG_BBGGRR_BBGGRR    kGRRBBG, kGRRBBG, kBBGGRR, kBBGGRR  
+#define kBRRGGB_BRRGGB_GGBBRR_GGBBRR    kBRRGGB, kBRRGGB, kGGBBRR, kGGBBRR  
+#define kGBBRRG_GBBRRG_RRGGBB_RRGGBB    kGBBRRG, kGBBRRG, kRRGGBB, kRRGGBB  
 
-const uint kShadowMasks4K600TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks4K600TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kGRRBBG_GRRBBG_BBGGRR_BBGGRR, kBRRGGB_BRRGGB_GGBBRR_GGBBRR, kGBBRRG_GBBRRG_RRGGBB_RRGGBB
 };
@@ -601,23 +601,23 @@ const uint kShadowMasks4K600TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSiz
 #define kMaxShadowMaskSizeX     2
 #define kMaxShadowMaskSizeY     2
 
-#define kMG                { kMagenta, kGreen }
-#define kGM                { kGreen, kMagenta }
+#define kMG                  kMagenta, kGreen  
+#define kGM                  kGreen, kMagenta  
 
-#define kYB                { kYellow, kBlue }
-#define kBY                { kBlue, kYellow }
+#define kYB                  kYellow, kBlue  
+#define kBY                  kBlue, kYellow  
 
-#define kMG_GM             { kMG, kGM }
-#define kYB_BY             { kYB, kBY }
-#define kGM_MG             { kGM, kMG }
+#define kMG_GM               kMG, kGM  
+#define kYB_BY               kYB, kBY  
+#define kGM_MG               kGM, kMG  
 
-const uint kShadowMasks4K800TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks4K800TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kMG_GM, kYB_BY, kGM_MG
 };
 
 // 1000 TVL
-const uint kShadowMasks4K1000TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks4K1000TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kMG_GM, kYB_BY, kGM_MG
 };
@@ -644,20 +644,20 @@ const uint kShadowMasks4K1000TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSi
 #define kMaxShadowMaskSizeX     12
 #define kMaxShadowMaskSizeY     8
 
-#define kGGRRRRBBBBGG      { kGreen, kGreen, kRed, kRed, kRed, kRed, kBlue, kBlue, kBlue, kBlue, kGreen, kGreen }
-#define kBBBBGGGGRRRR      { kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kRed, kRed, kRed, kRed }
+#define kGGRRRRBBBBGG        kGreen, kGreen, kRed, kRed, kRed, kRed, kBlue, kBlue, kBlue, kBlue, kGreen, kGreen  
+#define kBBBBGGGGRRRR        kBlue, kBlue, kBlue, kBlue, kGreen, kGreen, kGreen, kGreen, kRed, kRed, kRed, kRed  
 
-#define kBBRRRRGGGGBB      { kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue }
-#define kGGGGBBBBRRRR      { kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed }
+#define kBBRRRRGGGGBB        kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue  
+#define kGGGGBBBBRRRR        kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed  
 
-#define kGGBBBBRRRRGG      { kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen }
-#define kRRRRGGGGBBBB      { kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue }
+#define kGGBBBBRRRRGG        kGreen, kGreen, kBlue, kBlue, kBlue, kBlue, kRed, kRed, kRed, kRed, kGreen, kGreen  
+#define kRRRRGGGGBBBB        kRed, kRed, kRed, kRed, kGreen, kGreen, kGreen, kGreen, kBlue, kBlue, kBlue, kBlue  
 
-#define kGGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR  { kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR }
-#define kBBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR  { kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR }
-#define kGGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB  { kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB }
+#define kGGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR    kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kGGRRRRBBBBGG, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR, kBBBBGGGGRRRR  
+#define kBBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR    kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kBBRRRRGGGGBB, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR, kGGGGBBBBRRRR  
+#define kGGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_GGBBBBRRRRGG_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB_RRRRGGGGBBBB    kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kGGBBBBRRRRGG, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB, kRRRRGGGGBBBB  
 
-const uint kShadowMasks8K300TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks8K300TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kGGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR,
    kBBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR,
@@ -665,7 +665,7 @@ const uint kShadowMasks8K300TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSiz
 };
 
 // 600 TVL
-const uint kShadowMasks8K600TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks8K600TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kGGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_GGRRRRBBBBGG_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR_BBBBGGGGRRRR, 
    kBBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_BBRRRRGGGGBB_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR_GGGGBBBBRRRR,
@@ -692,26 +692,26 @@ const uint kShadowMasks8K600TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSiz
 #define kMaxShadowMaskSizeX     6
 #define kMaxShadowMaskSizeY     4
 
-#define kGRRBBG            { kGreen, kRed, kRed, kBlue, kBlue, kGreen }
-#define kBBGGRR            { kBlue, kBlue, kGreen, kGreen, kRed, kRed }
+#define kGRRBBG              kGreen, kRed, kRed, kBlue, kBlue, kGreen  
+#define kBBGGRR              kBlue, kBlue, kGreen, kGreen, kRed, kRed  
 
-#define kBRRGGB            { kBlue, kRed, kRed, kGreen, kGreen, kBlue }
-#define kGGBBRR            { kGreen, kGreen, kBlue, kBlue, kRed, kRed }
+#define kBRRGGB              kBlue, kRed, kRed, kGreen, kGreen, kBlue  
+#define kGGBBRR              kGreen, kGreen, kBlue, kBlue, kRed, kRed  
 
-#define kGBBRRG            { kGreen, kBlue, kBlue, kRed, kRed, kGreen }
-#define kRRGGBB            { kRed, kRed, kGreen, kGreen, kBlue, kBlue }
+#define kGBBRRG              kGreen, kBlue, kBlue, kRed, kRed, kGreen  
+#define kRRGGBB              kRed, kRed, kGreen, kGreen, kBlue, kBlue  
 
-#define kGRRBBG_GRRBBG_BBGGRR_BBGGRR  { kGRRBBG, kGRRBBG, kBBGGRR, kBBGGRR }
-#define kBRRGGB_BRRGGB_GGBBRR_GGBBRR  { kBRRGGB, kBRRGGB, kGGBBRR, kGGBBRR }
-#define kGBBRRG_GBBRRG_RRGGBB_RRGGBB  { kGBBRRG, kGBBRRG, kRRGGBB, kRRGGBB }
+#define kGRRBBG_GRRBBG_BBGGRR_BBGGRR    kGRRBBG, kGRRBBG, kBBGGRR, kBBGGRR  
+#define kBRRGGB_BRRGGB_GGBBRR_GGBBRR    kBRRGGB, kBRRGGB, kGGBBRR, kGGBBRR  
+#define kGBBRRG_GBBRRG_RRGGBB_RRGGBB    kGBBRRG, kGBBRRG, kRRGGBB, kRRGGBB  
 
-const uint kShadowMasks8K800TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks8K800TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kGRRBBG_GRRBBG_BBGGRR_BBGGRR, kBRRGGB_BRRGGB_GGBBRR_GGBBRR, kGBBRRG_GBBRRG_RRGGBB_RRGGBB
 };
 
 // 1000 TVL
-const uint kShadowMasks8K1000TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSizeX]  = 
+const uint kShadowMasks8K1000TVL[kBGRAxis * kMaxShadowMaskSizeY * kMaxShadowMaskSizeX]  = 
 {
    kGRRBBG_GRRBBG_BBGGRR_BBGGRR, kBRRGGB_BRRGGB_GGBBRR_GGBBRR, kGBBRRG_GBBRRG_RRGGBB_RRGGBB
 };
@@ -736,8 +736,8 @@ const uint kShadowMasks8K1000TVL[kBGRAxis][kMaxShadowMaskSizeY][kMaxShadowMaskSi
 
 #define kMaxSlotSizeX      2
 
-const float kSlotMaskSizeX[kResolutionAxis][kTVLAxis] = { { 4.0f, 2.0f, 1.0f, 1.0f }, { 7.0f, 4.0f, 3.0f, 2.0f }, { 7.0f, 7.0f, 5.0f, 4.0f } }; //1080p: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   4K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   8K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL
-const float kSlotMaskSizeY[kResolutionAxis][kTVLAxis] = { { 4.0f, 4.0f, 1.0f, 1.0f }, { 8.0f, 6.0f, 4.0f, 4.0f }, { 6.0f, 6.0f, 4.0f, 4.0f } }; //1080p: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   4K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   8K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL
+const float kSlotMaskSizeX[kResolutionAxis * kTVLAxis] = {   4.0f, 2.0f, 1.0f, 1.0f  ,   7.0f, 4.0f, 3.0f, 2.0f  ,   7.0f, 7.0f, 5.0f, 4.0f   }; //1080p: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   4K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   8K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL
+const float kSlotMaskSizeY[kResolutionAxis * kTVLAxis] = {   4.0f, 4.0f, 1.0f, 1.0f  ,   8.0f, 6.0f, 4.0f, 4.0f  ,   6.0f, 6.0f, 4.0f, 4.0f   }; //1080p: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   4K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   8K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL
 
 
 // 1080p 
@@ -747,17 +747,17 @@ const float kSlotMaskSizeY[kResolutionAxis][kTVLAxis] = { { 4.0f, 4.0f, 1.0f, 1.
 #define kMaxSlotMaskSize   4
 #define kMaxSlotSizeY      4
 
-#define kXXXX     { kBlack, kBlack, kBlack, kBlack }
+#define kXXXX       kBlack, kBlack, kBlack, kBlack  
 
-#define kRGBX     { kRed, kGreen, kBlue, kBlack }
-#define kRBGX     { kRed, kBlue, kGreen, kBlack }
-#define kBGRX     { kBlue, kGreen, kRed, kBlack }
+#define kRGBX       kRed, kGreen, kBlue, kBlack  
+#define kRBGX       kRed, kBlue, kGreen, kBlack  
+#define kBGRX       kBlue, kGreen, kRed, kBlack  
 
-#define kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX   { { kRGBX, kRGBX }, { kRGBX, kXXXX }, { kRGBX, kRGBX }, { kXXXX, kRGBX } }
-#define kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX   { { kRBGX, kRBGX }, { kRBGX, kXXXX }, { kRBGX, kRBGX }, { kXXXX, kRBGX } }
-#define kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX   { { kBGRX, kBGRX }, { kBGRX, kXXXX }, { kBGRX, kBGRX }, { kXXXX, kBGRX } }
+#define kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX       kRGBX, kRGBX  ,   kRGBX, kXXXX  ,   kRGBX, kRGBX  ,   kXXXX, kRGBX    
+#define kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX       kRBGX, kRBGX  ,   kRBGX, kXXXX  ,   kRBGX, kRBGX  ,   kXXXX, kRBGX    
+#define kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX       kBGRX, kBGRX  ,   kBGRX, kXXXX  ,   kBGRX, kBGRX  ,   kXXXX, kBGRX    
 
-const uint kSlotMasks1080p300TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks1080p300TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX, kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX, kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX                                                                                       
 };
@@ -780,17 +780,17 @@ const uint kSlotMasks1080p300TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlo
 #define kMaxSlotMaskSize   2
 #define kMaxSlotSizeY      4
 
-#define kXX     { kBlack, kBlack }
+#define kXX       kBlack, kBlack  
 
-#define kMG       { kMagenta, kGreen }
-#define kYB       { kYellow, kBlue }
-#define kGM       { kGreen, kMagenta }
+#define kMG         kMagenta, kGreen  
+#define kYB         kYellow, kBlue  
+#define kGM         kGreen, kMagenta  
 
-#define kMGMG_MGXX_MGMG_XXMG   { { kMG, kMG }, { kMG, kXX }, { kMG, kMG }, { kXX, kMG } }
-#define kYBYB_YBXX_YBYB_XXYB   { { kYB, kYB }, { kYB, kXX }, { kYB, kYB }, { kXX, kYB } }
-#define kGMGM_GMXX_GMGM_XXGM   { { kGM, kGM }, { kGM, kXX }, { kGM, kGM }, { kXX, kGM } }
+#define kMGMG_MGXX_MGMG_XXMG       kMG, kMG  ,   kMG, kXX  ,   kMG, kMG  ,   kXX, kMG    
+#define kYBYB_YBXX_YBYB_XXYB       kYB, kYB  ,   kYB, kXX  ,   kYB, kYB  ,   kXX, kYB    
+#define kGMGM_GMXX_GMGM_XXGM       kGM, kGM  ,   kGM, kXX  ,   kGM, kGM  ,   kXX, kGM    
 
-const uint kSlotMasks1080p600TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks1080p600TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kMGMG_MGXX_MGMG_XXMG, kYBYB_YBXX_YBYB_XXYB, kGMGM_GMXX_GMGM_XXGM
 };
@@ -813,18 +813,18 @@ const uint kSlotMasks1080p600TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlo
 #define kMaxSlotMaskSize   1
 #define kMaxSlotSizeY      4
 
-#define kX        { kBlack }
-#define kW        { kWhite }
+#define kX          kBlack  
+#define kW          kWhite  
 
-#define kW_W_W_W   { { kW, kW }, { kW, kX }, { kW, kW }, { kX, kW } }
+#define kW_W_W_W       kW, kW  ,   kW, kX  ,   kW, kW  ,   kX, kW    
 
-const uint kSlotMasks1080p800TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks1080p800TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kW_W_W_W, kW_W_W_W, kW_W_W_W
 };
 
 // 1000 TVL
-const uint kSlotMasks1080p1000TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks1080p1000TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kW_W_W_W, kW_W_W_W, kW_W_W_W 
 };
@@ -844,17 +844,17 @@ const uint kSlotMasks1080p1000TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSl
 #define kMaxSlotMaskSize   7
 #define kMaxSlotSizeY      8
 
-#define kXXXX     { kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
+#define kXXXX       kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
 
-#define kRRGGBBX  { kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack }
-#define kRRBBGGX  { kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack }
-#define kBBGGRRX  { kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack }
+#define kRRGGBBX    kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack  
+#define kRRBBGGX    kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack  
+#define kBBGGRRX    kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack  
 
-#define kRRGGBBXRRGGBBX_RRGGBBXRRGGBBX_RRGGBBXXXXX_RRGGBBXRRGGBBX_RRGGBBXRRGGBBX_XXXXRRGGBBX   { { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kXXXX }, { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kRRGGBBX }, { kXXXX, kRRGGBBX } }
-#define kRRBBGGXRRBBGGX_RRBBGGXRRBBGGX_RRBBGGXXXXX_RRBBGGXRRBBGGX_RRBBGGXRRBBGGX_XXXXRRBBGGX   { { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kXXXX }, { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kRRBBGGX }, { kXXXX, kRRBBGGX } }
-#define kBBGGRRXBBGGRRX_BBGGRRXBBGGRRX_BBGGRRXXXXX_BBGGRRXBBGGRRX_BBGGRRXBBGGRRX_XXXXBBGGRRX   { { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kXXXX }, { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kBBGGRRX }, { kXXXX, kBBGGRRX } }
+#define kRRGGBBXRRGGBBX_RRGGBBXRRGGBBX_RRGGBBXXXXX_RRGGBBXRRGGBBX_RRGGBBXRRGGBBX_XXXXRRGGBBX       kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kXXXX  ,   kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kRRGGBBX  ,   kXXXX, kRRGGBBX    
+#define kRRBBGGXRRBBGGX_RRBBGGXRRBBGGX_RRBBGGXXXXX_RRBBGGXRRBBGGX_RRBBGGXRRBBGGX_XXXXRRBBGGX       kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kXXXX  ,   kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kRRBBGGX  ,   kXXXX, kRRBBGGX    
+#define kBBGGRRXBBGGRRX_BBGGRRXBBGGRRX_BBGGRRXXXXX_BBGGRRXBBGGRRX_BBGGRRXBBGGRRX_XXXXBBGGRRX       kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kXXXX  ,   kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kBBGGRRX  ,   kXXXX, kBBGGRRX    
 
-const uint kSlotMasks4K300TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks4K300TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kRRGGBBXRRGGBBX_RRGGBBXRRGGBBX_RRGGBBXXXXX_RRGGBBXRRGGBBX_RRGGBBXRRGGBBX_XXXXRRGGBBX, kRRBBGGXRRBBGGX_RRBBGGXRRBBGGX_RRBBGGXXXXX_RRBBGGXRRBBGGX_RRBBGGXRRBBGGX_XXXXRRBBGGX, kBBGGRRXBBGGRRX_BBGGRRXBBGGRRX_BBGGRRXXXXX_BBGGRRXBBGGRRX_BBGGRRXBBGGRRX_XXXXBBGGRRX
 };
@@ -877,17 +877,17 @@ const uint kSlotMasks4K300TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMa
 #define kMaxSlotMaskSize   4
 #define kMaxSlotSizeY      6
 
-#define kXXXX     { kBlack, kBlack, kBlack, kBlack }
+#define kXXXX       kBlack, kBlack, kBlack, kBlack  
 
-#define kRGBX     { kRed, kGreen, kBlue, kBlack }
-#define kRBGX     { kRed, kBlue, kGreen, kBlack }
-#define kBGRX     { kBlue, kGreen, kRed, kBlack }
+#define kRGBX       kRed, kGreen, kBlue, kBlack  
+#define kRBGX       kRed, kBlue, kGreen, kBlack  
+#define kBGRX       kBlue, kGreen, kRed, kBlack  
 
-#define kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX   { { kRGBX, kRGBX }, { kRGBX, kRGBX }, { kRGBX, kXXXX }, { kRGBX, kRGBX }, { kRGBX, kRGBX }, { kXXXX, kRGBX }}
-#define kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX   { { kRBGX, kRBGX }, { kRBGX, kRBGX }, { kRBGX, kXXXX }, { kRBGX, kRBGX }, { kRBGX, kRBGX }, { kXXXX, kRBGX }}
-#define kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX   { { kBGRX, kBGRX }, { kBGRX, kBGRX }, { kBGRX, kXXXX }, { kBGRX, kBGRX }, { kBGRX, kBGRX }, { kXXXX, kBGRX }}
+#define kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX       kRGBX, kRGBX  ,   kRGBX, kRGBX  ,   kRGBX, kXXXX  ,   kRGBX, kRGBX  ,   kRGBX, kRGBX  ,   kXXXX, kRGBX   
+#define kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX       kRBGX, kRBGX  ,   kRBGX, kRBGX  ,   kRBGX, kXXXX  ,   kRBGX, kRBGX  ,   kRBGX, kRBGX  ,   kXXXX, kRBGX   
+#define kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX       kBGRX, kBGRX  ,   kBGRX, kBGRX  ,   kBGRX, kXXXX  ,   kBGRX, kBGRX  ,   kBGRX, kBGRX  ,   kXXXX, kBGRX   
 
-const uint kSlotMasks4K600TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks4K600TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX, kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX, kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX
 };
@@ -910,17 +910,17 @@ const uint kSlotMasks4K600TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMa
 #define kMaxSlotMaskSize   3
 #define kMaxSlotSizeY      4
 
-#define kXXXX     { kBlack, kBlack, kBlack }
+#define kXXXX       kBlack, kBlack, kBlack  
 
-#define kBGR      { kBlue, kGreen, kRed }
-#define kGBR      { kGreen, kBlue, kRed }
-#define kRGB      { kRed, kGreen, kBlue }
+#define kBGR        kBlue, kGreen, kRed  
+#define kGBR        kGreen, kBlue, kRed  
+#define kRGB        kRed, kGreen, kBlue  
 
-#define kBGRBGR_BGRXXX_BGRBGR_XXXBGR   { { kBGR, kBGR }, { kBGR, kXXXX }, { kBGR, kBGR }, { kXXXX, kBGR } }
-#define kGBRGBR_GBRXXX_GBRGBR_XXXGBR   { { kGBR, kGBR }, { kGBR, kXXXX }, { kGBR, kGBR }, { kXXXX, kGBR } }
-#define kRGBRGB_RGBXXX_RGBRGB_XXXRGB   { { kRGB, kRGB }, { kRGB, kXXXX }, { kRGB, kRGB }, { kXXXX, kRGB } }
+#define kBGRBGR_BGRXXX_BGRBGR_XXXBGR       kBGR, kBGR  ,   kBGR, kXXXX  ,   kBGR, kBGR  ,   kXXXX, kBGR    
+#define kGBRGBR_GBRXXX_GBRGBR_XXXGBR       kGBR, kGBR  ,   kGBR, kXXXX  ,   kGBR, kGBR  ,   kXXXX, kGBR    
+#define kRGBRGB_RGBXXX_RGBRGB_XXXRGB       kRGB, kRGB  ,   kRGB, kXXXX  ,   kRGB, kRGB  ,   kXXXX, kRGB    
 
-const uint kSlotMasks4K800TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks4K800TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kBGRBGR_BGRXXX_BGRBGR_XXXBGR, kGBRGBR_GBRXXX_GBRGBR_XXXGBR, kRGBRGB_RGBXXX_RGBRGB_XXXRGB
 };
@@ -943,17 +943,17 @@ const uint kSlotMasks4K800TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMa
 #define kMaxSlotMaskSize   2
 #define kMaxSlotSizeY      4
 
-#define kXX     { kBlack, kBlack }
+#define kXX       kBlack, kBlack  
 
-#define kMG       { kMagenta, kGreen }
-#define kYB       { kYellow, kBlue }
-#define kGM       { kGreen, kMagenta }
+#define kMG         kMagenta, kGreen  
+#define kYB         kYellow, kBlue  
+#define kGM         kGreen, kMagenta  
 
-#define kMGMG_MGXX_MGMG_XXMG   { { kMG, kMG }, { kMG, kXX }, { kMG, kMG }, { kXX, kMG } }
-#define kYBYB_YBXX_YBYB_XXYB   { { kYB, kYB }, { kYB, kXX }, { kYB, kYB }, { kXX, kYB } }
-#define kGMGM_GMXX_GMGM_XXGM   { { kGM, kGM }, { kGM, kXX }, { kGM, kGM }, { kXX, kGM } }
+#define kMGMG_MGXX_MGMG_XXMG       kMG, kMG  ,   kMG, kXX  ,   kMG, kMG  ,   kXX, kMG    
+#define kYBYB_YBXX_YBYB_XXYB       kYB, kYB  ,   kYB, kXX  ,   kYB, kYB  ,   kXX, kYB    
+#define kGMGM_GMXX_GMGM_XXGM       kGM, kGM  ,   kGM, kXX  ,   kGM, kGM  ,   kXX, kGM    
 
-const uint kSlotMasks4K1000TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks4K1000TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kMGMG_MGXX_MGMG_XXMG, kYBYB_YBXX_YBYB_XXYB, kGMGM_GMXX_GMGM_XXGM
 };
@@ -979,23 +979,23 @@ const uint kSlotMasks4K1000TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotM
 #define kMaxSlotMaskSize   7
 #define kMaxSlotSizeY      6
 
-#define kXXXX     { kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
+#define kXXXX       kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
 
-#define kRRGGBBX  { kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack }
-#define kRRBBGGX  { kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack }
-#define kBBGGRRX  { kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack }
+#define kRRGGBBX    kRed, kRed, kGreen, kGreen, kBlue, kBlue, kBlack  
+#define kRRBBGGX    kRed, kRed, kBlue, kBlue, kGreen, kGreen, kBlack  
+#define kBBGGRRX    kBlue, kBlue, kGreen, kGreen, kRed, kRed, kBlack  
 
-#define kRRGGBBXRRGGBBX_RRGGBBXRRGGBBX_RRGGBBXXXXX_RRGGBBXRRGGBBX_RRGGBBXRRGGBBX_XXXXRRGGBBX   { { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kXXXX }, { kRRGGBBX, kRRGGBBX }, { kRRGGBBX, kRRGGBBX }, { kXXXX, kRRGGBBX } }
-#define kRRBBGGXRRBBGGX_RRBBGGXRRBBGGX_RRBBGGXXXXX_RRBBGGXRRBBGGX_RRBBGGXRRBBGGX_XXXXRRBBGGX   { { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kXXXX }, { kRRBBGGX, kRRBBGGX }, { kRRBBGGX, kRRBBGGX }, { kXXXX, kRRBBGGX } }
-#define kBBGGRRXBBGGRRX_BBGGRRXBBGGRRX_BBGGRRXXXXX_BBGGRRXBBGGRRX_BBGGRRXBBGGRRX_XXXXBBGGRRX   { { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kXXXX }, { kBBGGRRX, kBBGGRRX }, { kBBGGRRX, kBBGGRRX }, { kXXXX, kBBGGRRX } }
+#define kRRGGBBXRRGGBBX_RRGGBBXRRGGBBX_RRGGBBXXXXX_RRGGBBXRRGGBBX_RRGGBBXRRGGBBX_XXXXRRGGBBX       kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kXXXX  ,   kRRGGBBX, kRRGGBBX  ,   kRRGGBBX, kRRGGBBX  ,   kXXXX, kRRGGBBX    
+#define kRRBBGGXRRBBGGX_RRBBGGXRRBBGGX_RRBBGGXXXXX_RRBBGGXRRBBGGX_RRBBGGXRRBBGGX_XXXXRRBBGGX       kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kXXXX  ,   kRRBBGGX, kRRBBGGX  ,   kRRBBGGX, kRRBBGGX  ,   kXXXX, kRRBBGGX    
+#define kBBGGRRXBBGGRRX_BBGGRRXBBGGRRX_BBGGRRXXXXX_BBGGRRXBBGGRRX_BBGGRRXBBGGRRX_XXXXBBGGRRX       kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kXXXX  ,   kBBGGRRX, kBBGGRRX  ,   kBBGGRRX, kBBGGRRX  ,   kXXXX, kBBGGRRX    
 
-const uint kSlotMasks8K300TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks8K300TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kRRGGBBXRRGGBBX_RRGGBBXRRGGBBX_RRGGBBXXXXX_RRGGBBXRRGGBBX_RRGGBBXRRGGBBX_XXXXRRGGBBX, kRRBBGGXRRBBGGX_RRBBGGXRRBBGGX_RRBBGGXXXXX_RRBBGGXRRBBGGX_RRBBGGXRRBBGGX_XXXXRRBBGGX, kBBGGRRXBBGGRRX_BBGGRRXBBGGRRX_BBGGRRXXXXX_BBGGRRXBBGGRRX_BBGGRRXBBGGRRX_XXXXBBGGRRX 
 };
 
 // 600 TVL
-const uint kSlotMasks8K600TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks8K600TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kRRGGBBXRRGGBBX_RRGGBBXRRGGBBX_RRGGBBXXXXX_RRGGBBXRRGGBBX_RRGGBBXRRGGBBX_XXXXRRGGBBX, kRRBBGGXRRBBGGX_RRBBGGXRRBBGGX_RRBBGGXXXXX_RRBBGGXRRBBGGX_RRBBGGXRRBBGGX_XXXXRRBBGGX, kBBGGRRXBBGGRRX_BBGGRRXBBGGRRX_BBGGRRXXXXX_BBGGRRXBBGGRRX_BBGGRRXBBGGRRX_XXXXBBGGRRX 
 };
@@ -1017,17 +1017,17 @@ const uint kSlotMasks8K600TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMa
 #define kMaxSlotMaskSize   5
 #define kMaxSlotSizeY      4
 
-#define kXXXX     { kBlack, kBlack, kBlack, kBlack, kBlack }
+#define kXXXX       kBlack, kBlack, kBlack, kBlack, kBlack  
 
-#define kRYCBX    { kRed, kYellow, kCyan, kBlue, kBlack }
-#define kRMCGX    { kRed, kMagenta, kCyan, kGreen, kBlack }
-#define kBCYRX    { kBlue, kCyan, kYellow, kRed, kBlack }
+#define kRYCBX      kRed, kYellow, kCyan, kBlue, kBlack  
+#define kRMCGX      kRed, kMagenta, kCyan, kGreen, kBlack  
+#define kBCYRX      kBlue, kCyan, kYellow, kRed, kBlack  
 
-#define kRYCBXRYCBX_RYCBXXXXX_RYCBXRYCBX_XXXXRYCBX   { { kRYCBX, kRYCBX }, { kRYCBX, kXXXX }, { kRYCBX, kRYCBX }, { kXXXX, kRYCBX } }
-#define kRMCGXRMCGX_RMCGXXXXX_RMCGXRMCGX_XXXXRMCGX   { { kRMCGX, kRMCGX }, { kRMCGX, kXXXX }, { kRMCGX, kRMCGX }, { kXXXX, kRMCGX } }
-#define kBCYRXBCYRX_BCYRXXXXX_BCYRXBCYRX_XXXXBCYRX   { { kBCYRX, kBCYRX }, { kBCYRX, kXXXX }, { kBCYRX, kBCYRX }, { kXXXX, kBCYRX } }
+#define kRYCBXRYCBX_RYCBXXXXX_RYCBXRYCBX_XXXXRYCBX       kRYCBX, kRYCBX  ,   kRYCBX, kXXXX  ,   kRYCBX, kRYCBX  ,   kXXXX, kRYCBX    
+#define kRMCGXRMCGX_RMCGXXXXX_RMCGXRMCGX_XXXXRMCGX       kRMCGX, kRMCGX  ,   kRMCGX, kXXXX  ,   kRMCGX, kRMCGX  ,   kXXXX, kRMCGX    
+#define kBCYRXBCYRX_BCYRXXXXX_BCYRXBCYRX_XXXXBCYRX       kBCYRX, kBCYRX  ,   kBCYRX, kXXXX  ,   kBCYRX, kBCYRX  ,   kXXXX, kBCYRX    
 
-const uint kSlotMasks8K800TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks8K800TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kRYCBXRYCBX_RYCBXXXXX_RYCBXRYCBX_XXXXRYCBX, kRMCGXRMCGX_RMCGXXXXX_RMCGXRMCGX_XXXXRMCGX, kBCYRXBCYRX_BCYRXXXXX_BCYRXBCYRX_XXXXBCYRX
 };
@@ -1050,17 +1050,17 @@ const uint kSlotMasks8K800TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMa
 #define kMaxSlotMaskSize   4
 #define kMaxSlotSizeY      4
 
-#define kXXXX     { kBlack, kBlack, kBlack, kBlack }
+#define kXXXX       kBlack, kBlack, kBlack, kBlack  
 
-#define kRGBX     { kRed, kGreen, kBlue, kBlack }
-#define kRBGX     { kRed, kBlue, kGreen, kBlack }
-#define kBGRX     { kBlue, kGreen, kRed, kBlack }
+#define kRGBX       kRed, kGreen, kBlue, kBlack  
+#define kRBGX       kRed, kBlue, kGreen, kBlack  
+#define kBGRX       kBlue, kGreen, kRed, kBlack  
 
-#define kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX   { { kRGBX, kRGBX }, { kRGBX, kXXXX }, { kRGBX, kRGBX }, { kXXXX, kRGBX } }
-#define kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX   { { kRBGX, kRBGX }, { kRBGX, kXXXX }, { kRBGX, kRBGX }, { kXXXX, kRBGX } }
-#define kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX   { { kBGRX, kBGRX }, { kBGRX, kXXXX }, { kBGRX, kBGRX }, { kXXXX, kBGRX } }
+#define kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX       kRGBX, kRGBX  ,   kRGBX, kXXXX  ,   kRGBX, kRGBX  ,   kXXXX, kRGBX    
+#define kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX       kRBGX, kRBGX  ,   kRBGX, kXXXX  ,   kRBGX, kRBGX  ,   kXXXX, kRBGX    
+#define kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX       kBGRX, kBGRX  ,   kBGRX, kXXXX  ,   kBGRX, kBGRX  ,   kXXXX, kBGRX    
 
-const uint kSlotMasks8K1000TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotMaskSize] = 
+const uint kSlotMasks8K1000TVL[kBGRAxis * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize] = 
 {
    kRGBXRGBX_RGBXXXXX_RGBXRGBX_XXXXRGBX, kRBGXRBGX_RBGXXXXX_RBGXRBGX_XXXXRBGX, kBGRXBGRX_BGRXXXXX_BGRXBGRX_XXXXBGRX 
 };
@@ -1083,18 +1083,18 @@ const uint kSlotMasks8K1000TVL[kBGRAxis][kMaxSlotSizeY][kMaxSlotSizeX][kMaxSlotM
 
 #define kMaxBlackWhiteSize       14
 
-#define kW                 { kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
+#define kW                   kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
 
-#define kWX                { kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
-#define kWWX               { kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
-#define kWWXX              { kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
-#define kWWWWX             { kWhite, kWhite, kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
-#define kWWWWWXX           { kWhite, kWhite, kWhite, kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack }
-#define kWWWWWWWWWWWXXX    { kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite /*kBlack, kBlack, kBlack*/ }
+#define kWX                  kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
+#define kWWX                 kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
+#define kWWXX                kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
+#define kWWWWX               kWhite, kWhite, kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
+#define kWWWWWXX             kWhite, kWhite, kWhite, kWhite, kWhite, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack, kBlack  
+#define kWWWWWWWWWWWXXX      kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite, kWhite /*kBlack, kBlack, kBlack*/  
 
-const float kBlackWhiteMaskSize[kResolutionAxis][kTVLAxis] = { { 4.0f, 2.0f, 1.0f, 1.0f }, { 7.0f, 4.0f, 3.0f, 2.0f }, { 14.0f, 7.0f, 5.0f, 4.0f } }; //4K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   8K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL
+const float kBlackWhiteMaskSize[kResolutionAxis * kTVLAxis] = {   4.0f, 2.0f, 1.0f, 1.0f  ,   7.0f, 4.0f, 3.0f, 2.0f  ,   14.0f, 7.0f, 5.0f, 4.0f   }; //4K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL   8K: 300 TVL, 600 TVL, 800 TVL, 1000 TVL
 
-const uint kBlackWhiteMasks[kResolutionAxis][kTVLAxis][kBGRAxis][kMaxBlackWhiteSize] = {
+const uint kBlackWhiteMasks[kResolutionAxis * kTVLAxis * kBGRAxis * kMaxBlackWhiteSize] = {
    { // 1080p
       { kWWXX, kWWXX, kWWXX },                                 // 300 TVL
       { kWX, kWX, kWX },                                       // 600 TVL
@@ -1156,11 +1156,13 @@ void main()
 
    uint colour_mask = 0;
 
-   switch(screen_type)
+  switch(screen_type)
    {
       case kApertureGrille:
       {
-         uint mask = uint(floor(mod(current_position.x, kApertureGrilleMaskSize[lcd_resolution][crt_resolution])));
+         uint mask = uint(floor(mod(current_position.x, kApertureGrilleMaskSize[(lcd_resolution * kTVLAxis) + crt_resolution])));
+
+         mask = mask;
 
          switch(lcd_resolution)
          {
@@ -1170,25 +1172,25 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kApertureGrilleMasks1080p300TVL[lcd_subpixel_layout][mask];      
+                     colour_mask = kApertureGrilleMasks1080p300TVL[(lcd_subpixel_layout * 4) + mask];      
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kApertureGrilleMasks1080p600TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks1080p600TVL[(lcd_subpixel_layout * 2) + mask]; 
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kApertureGrilleMasks1080p800TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks1080p800TVL[(lcd_subpixel_layout * 1) + mask]; 
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kApertureGrilleMasks1080p1000TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks1080p1000TVL[(lcd_subpixel_layout * 1) + mask]; 
 
                      break;
                   }
@@ -1206,25 +1208,25 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kApertureGrilleMasks4K300TVL[lcd_subpixel_layout][mask];      
+                     colour_mask = kApertureGrilleMasks4K300TVL[(lcd_subpixel_layout * 7) + mask];      
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kApertureGrilleMasks4K600TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks4K600TVL[(lcd_subpixel_layout * 4) + mask]; 
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kApertureGrilleMasks4K800TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks4K800TVL[(lcd_subpixel_layout * 3) + mask]; 
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kApertureGrilleMasks4K1000TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks4K1000TVL[(lcd_subpixel_layout * 2) + mask]; 
 
                      break;
                   }
@@ -1242,25 +1244,25 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kApertureGrilleMasks8K300TVL[lcd_subpixel_layout][mask];      
+                     colour_mask = kApertureGrilleMasks8K300TVL[(lcd_subpixel_layout * 13) + mask];      
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kApertureGrilleMasks8K600TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks8K600TVL[(lcd_subpixel_layout * 7) + mask]; 
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kApertureGrilleMasks8K800TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks8K800TVL[(lcd_subpixel_layout * 5) + mask]; 
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kApertureGrilleMasks8K1000TVL[lcd_subpixel_layout][mask]; 
+                     colour_mask = kApertureGrilleMasks8K1000TVL[(lcd_subpixel_layout * 4) + mask]; 
 
                      break;
                   }
@@ -1282,9 +1284,9 @@ void main()
       }
       case kShadowMask:
       {
-         uint shadow_y = uint(floor(mod(current_position.y, kShadowMaskSizeY[lcd_resolution][crt_resolution])));
+         uint shadow_y = uint(floor(mod(current_position.y, kShadowMaskSizeY[(lcd_resolution * kTVLAxis) + crt_resolution])));
 
-         uint mask = uint(floor(mod(current_position.x, kShadowMaskSizeX[lcd_resolution][crt_resolution])));
+         uint mask = uint(floor(mod(current_position.x, kShadowMaskSizeX[(lcd_resolution * kTVLAxis) + crt_resolution])));
 
          switch(lcd_resolution)
          {
@@ -1294,25 +1296,25 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kShadowMasks1080p300TVL[lcd_subpixel_layout][shadow_y][mask];      
+                     colour_mask = kShadowMasks1080p300TVL[(lcd_subpixel_layout * 4 * 6) + (shadow_y * 6) + mask];      
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kShadowMasks1080p600TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks1080p600TVL[(lcd_subpixel_layout * 2 * 2) + (shadow_y * 2) + mask]; 
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kShadowMasks1080p800TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks1080p800TVL[(lcd_subpixel_layout * 1 * 1) + (shadow_y * 1) + mask]; 
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kShadowMasks1080p1000TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks1080p1000TVL[(lcd_subpixel_layout * 1 * 1) + (shadow_y * 1) + mask]; 
 
                      break;
                   }
@@ -1330,25 +1332,25 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kShadowMasks4K300TVL[lcd_subpixel_layout][shadow_y][mask];      
+                     colour_mask = kShadowMasks4K300TVL[(lcd_subpixel_layout * 8 * 12) + (shadow_y * 12) + mask];      
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kShadowMasks4K600TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks4K600TVL[(lcd_subpixel_layout * 4 * 6) + (shadow_y * 6) + mask]; 
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kShadowMasks4K800TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks4K800TVL[(lcd_subpixel_layout * 2 * 2) + (shadow_y * 2) + mask]; 
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kShadowMasks4K1000TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks4K1000TVL[(lcd_subpixel_layout * 2 * 2) + (shadow_y * 2) + mask]; 
 
                      break;
                   }
@@ -1366,25 +1368,25 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kShadowMasks8K300TVL[lcd_subpixel_layout][shadow_y][mask];      
+                     colour_mask = kShadowMasks8K300TVL[(lcd_subpixel_layout * 8 * 12) + (shadow_y * 12) + mask];      
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kShadowMasks8K600TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks8K600TVL[(lcd_subpixel_layout * 8 * 12) + (shadow_y * 12) + mask]; 
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kShadowMasks8K800TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks8K800TVL[(lcd_subpixel_layout * 4 * 6) + (shadow_y * 6) + mask]; 
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kShadowMasks8K1000TVL[lcd_subpixel_layout][shadow_y][mask]; 
+                     colour_mask = kShadowMasks8K1000TVL[(lcd_subpixel_layout * 4 * 6) + (shadow_y * 6) + mask]; 
 
                      break;
                   }
@@ -1406,10 +1408,10 @@ void main()
       }
       case kSlotMask:
       {
-         uint slot_x = uint(floor(mod(current_position.x / kSlotMaskSizeX[lcd_resolution][crt_resolution], kMaxSlotSizeX)));
-         uint slot_y = uint(floor(mod(current_position.y, kSlotMaskSizeY[lcd_resolution][crt_resolution])));
+         uint slot_x = uint(floor(mod(current_position.x / kSlotMaskSizeX[(lcd_resolution * kTVLAxis) + crt_resolution], kMaxSlotSizeX)));
+         uint slot_y = uint(floor(mod(current_position.y, kSlotMaskSizeY[(lcd_resolution * kTVLAxis) + crt_resolution])));
 
-         uint mask = uint(floor(mod(current_position.x, kSlotMaskSizeX[lcd_resolution][crt_resolution])));
+         uint mask = uint(floor(mod(current_position.x, kSlotMaskSizeX[(lcd_resolution * kTVLAxis) + crt_resolution])));
 
          switch(lcd_resolution)
          {
@@ -1419,25 +1421,49 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kSlotMasks1080p300TVL[lcd_subpixel_layout][slot_y][slot_x][mask];      
+                     #define kMaxSlotMaskSize   4
+                     #define kMaxSlotSizeY      4
                      
+                     colour_mask = kSlotMasks1080p300TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
+
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kSlotMasks1080p600TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   2
+                     #define kMaxSlotSizeY      4
+
+                     colour_mask = kSlotMasks1080p600TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kSlotMasks1080p800TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   1
+                     #define kMaxSlotSizeY      4
+
+                     colour_mask = kSlotMasks1080p800TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kSlotMasks1080p1000TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   1
+                     #define kMaxSlotSizeY      4
+
+                     colour_mask = kSlotMasks1080p1000TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
@@ -1455,25 +1481,49 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kSlotMasks4K300TVL[lcd_subpixel_layout][slot_y][slot_x][mask];      
+                     #define kMaxSlotMaskSize   7
+                     #define kMaxSlotSizeY      8
+
+                     colour_mask = kSlotMasks4K300TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];        
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY      
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kSlotMasks4K600TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   4
+                     #define kMaxSlotSizeY      6
+
+                     colour_mask = kSlotMasks4K600TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kSlotMasks4K800TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   3
+                     #define kMaxSlotSizeY      4
+
+                     colour_mask = kSlotMasks4K800TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kSlotMasks4K1000TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   2
+                     #define kMaxSlotSizeY      4
+
+                     colour_mask = kSlotMasks4K1000TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
@@ -1491,25 +1541,49 @@ void main()
                {
                   case k300TVL:
                   { 
-                     colour_mask = kSlotMasks8K300TVL[lcd_subpixel_layout][slot_y][slot_x][mask];      
+                     #define kMaxSlotMaskSize   7
+                     #define kMaxSlotSizeY      6
+
+                     colour_mask = kSlotMasks8K300TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY        
                      
                      break;
                   }
                   case k600TVL:
                   {
-                     colour_mask = kSlotMasks8K600TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   7
+                     #define kMaxSlotSizeY      6
+
+                     colour_mask = kSlotMasks8K600TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
                   case k800TVL:
                   {
-                     colour_mask = kSlotMasks8K800TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   5
+                     #define kMaxSlotSizeY      4
+
+                     colour_mask = kSlotMasks8K800TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
                   case k1000TVL:
                   {
-                     colour_mask = kSlotMasks8K1000TVL[lcd_subpixel_layout][slot_y][slot_x][mask]; 
+                     #define kMaxSlotMaskSize   4
+                     #define kMaxSlotSizeY      4
+
+                     colour_mask = kSlotMasks8K1000TVL[(lcd_subpixel_layout * kMaxSlotSizeY * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_y * kMaxSlotSizeX * kMaxSlotMaskSize) + (slot_x * kMaxSlotMaskSize) + mask];      
+                     
+                     #undef kMaxSlotMaskSize  
+                     #undef kMaxSlotSizeY   
 
                      break;
                   }
@@ -1532,9 +1606,9 @@ void main()
 #if ENABLE_BLACK_WHITE_MASKS
       case kBlackWhiteMask:
       {
-         uint mask = uint(floor(mod(current_position.x, kBlackWhiteMaskSize[lcd_resolution][crt_resolution])));
+         uint mask = uint(floor(mod(current_position.x, kBlackWhiteMaskSize[(lcd_resolution * kTVLAxis) + crt_resolution])));
 
-         colour_mask = kBlackWhiteMasks[lcd_resolution][crt_resolution][lcd_subpixel_layout][mask];      
+         colour_mask = kBlackWhiteMasks[(lcd_resolution * kTVLAxis * kBGRAxis * kMaxBlackWhiteSize) + (crt_resolution * kBGRAxis * kMaxBlackWhiteSize) + (lcd_subpixel_layout * kMaxBlackWhiteSize) + mask];      
 
          switch(lcd_resolution)
          {


### PR DESCRIPTION
Bring ReShade and RetroArch versions more inline with each other
Attempt to fix performance on android devices of shadow and slot masks