### PR TITLE
Restricted shader processing to the game screen area, fixing blurry cutoff point

### DIFF
--- a/handheld/console-border/shader-files/lcd-cgwg/lcd-grid-v2.slang
+++ b/handheld/console-border/shader-files/lcd-cgwg/lcd-grid-v2.slang
@@ -95,46 +95,53 @@ float intsmear(float x, float dx, float d, float coeffs[7])
 
 void main()
 {
-    vec2 texelSize = global.SourceSize.zw;
-    /* float2 range = IN.video_size / (IN.output_size * IN.texture_size); */
-    vec2 range = global.SourceSize.zw / screen_scale;
+    if(abs(vTexCoord.x - 0.5) < 0.5 && abs(vTexCoord.y - 0.5) < 0.5)
+    {
+        vec2 texelSize = global.SourceSize.zw;
+        /* float2 range = IN.video_size / (IN.output_size * IN.texture_size); */
+        vec2 range = global.SourceSize.zw / screen_scale;
 
-    vec3 cred   = pow(vec3(params.RSUBPIX_R, params.RSUBPIX_G, params.RSUBPIX_B), vec3(outgamma));
-    vec3 cgreen = pow(vec3(params.GSUBPIX_R, params.GSUBPIX_G, params.GSUBPIX_B), vec3(outgamma));
-    vec3 cblue  = pow(vec3(params.BSUBPIX_R, params.BSUBPIX_G, params.BSUBPIX_B), vec3(outgamma));
+        vec3 cred   = pow(vec3(params.RSUBPIX_R, params.RSUBPIX_G, params.RSUBPIX_B), vec3(outgamma));
+        vec3 cgreen = pow(vec3(params.GSUBPIX_R, params.GSUBPIX_G, params.GSUBPIX_B), vec3(outgamma));
+        vec3 cblue  = pow(vec3(params.BSUBPIX_R, params.BSUBPIX_G, params.BSUBPIX_B), vec3(outgamma));
 
-    ivec2 tli = ivec2(floor(vTexCoord/texelSize-vec2(0.4999)));
+        ivec2 tli = ivec2(floor(vTexCoord/texelSize-vec2(0.4999)));
 
-    vec3 lcol, rcol;
-    float subpix = (vTexCoord.x/texelSize.x - 0.4999 - float(tli.x))*3.0;
-    float rsubpix = range.x/texelSize.x * 3.0;
+        vec3 lcol, rcol;
+        float subpix = (vTexCoord.x/texelSize.x - 0.4999 - float(tli.x))*3.0;
+        float rsubpix = range.x/texelSize.x * 3.0;
 
-    lcol = vec3(intsmear(subpix+1.0, rsubpix, 1.5, coeffs_x),
-                intsmear(subpix    , rsubpix, 1.5, coeffs_x),
-                intsmear(subpix-1.0, rsubpix, 1.5, coeffs_x));
-    rcol = vec3(intsmear(subpix-2.0, rsubpix, 1.5, coeffs_x),
-                intsmear(subpix-3.0, rsubpix, 1.5, coeffs_x),
-                intsmear(subpix-4.0, rsubpix, 1.5, coeffs_x));
+        lcol = vec3(intsmear(subpix+1.0, rsubpix, 1.5, coeffs_x),
+                    intsmear(subpix    , rsubpix, 1.5, coeffs_x),
+                    intsmear(subpix-1.0, rsubpix, 1.5, coeffs_x));
+        rcol = vec3(intsmear(subpix-2.0, rsubpix, 1.5, coeffs_x),
+                    intsmear(subpix-3.0, rsubpix, 1.5, coeffs_x),
+                    intsmear(subpix-4.0, rsubpix, 1.5, coeffs_x));
 
-    if (params.BGR > 0.5) {
-        lcol.rgb = lcol.bgr;
-        rcol.rgb = rcol.bgr;
+        if (params.BGR > 0.5) {
+            lcol.rgb = lcol.bgr;
+            rcol.rgb = rcol.bgr;
+        }
+
+        float tcol, bcol;
+        subpix = vTexCoord.y/texelSize.y - 0.4999 - float(tli.y);
+        rsubpix = range.y/texelSize.y;
+        tcol = intsmear(subpix    ,rsubpix, 0.63, coeffs_y);
+        bcol = intsmear(subpix-1.0,rsubpix, 0.63, coeffs_y);
+
+        vec3 topLeftColor     = fetch_offset(tli, ivec2(0,0)) * lcol * vec3(tcol);
+        vec3 bottomRightColor = fetch_offset(tli, ivec2(1,1)) * rcol * vec3(bcol);
+        vec3 bottomLeftColor  = fetch_offset(tli, ivec2(0,1)) * lcol * vec3(bcol);
+        vec3 topRightColor    = fetch_offset(tli, ivec2(1,0)) * rcol * vec3(tcol);
+
+        vec3 averageColor = topLeftColor + bottomRightColor + bottomLeftColor + topRightColor;
+
+        averageColor = mat3(cred, cgreen, cblue) * averageColor;
+
+        FragColor = vec4(pow(averageColor, vec3(1.0/outgamma)),0.0);
     }
-
-    float tcol, bcol;
-    subpix = vTexCoord.y/texelSize.y - 0.4999 - float(tli.y);
-    rsubpix = range.y/texelSize.y;
-    tcol = intsmear(subpix    ,rsubpix, 0.63, coeffs_y);
-    bcol = intsmear(subpix-1.0,rsubpix, 0.63, coeffs_y);
-
-    vec3 topLeftColor     = fetch_offset(tli, ivec2(0,0)) * lcol * vec3(tcol);
-    vec3 bottomRightColor = fetch_offset(tli, ivec2(1,1)) * rcol * vec3(bcol);
-    vec3 bottomLeftColor  = fetch_offset(tli, ivec2(0,1)) * lcol * vec3(bcol);
-    vec3 topRightColor    = fetch_offset(tli, ivec2(1,0)) * rcol * vec3(tcol);
-
-    vec3 averageColor = topLeftColor + bottomRightColor + bottomLeftColor + topRightColor;
-
-    averageColor = mat3(cred, cgreen, cblue) * averageColor;
-
-    FragColor = vec4(pow(averageColor, vec3(1.0/outgamma)),0.0);
+    else
+    {
+        FragColor = vec4(0.0);
+    }
 }

--- a/handheld/console-border/shader-files/lcd-cgwg/lcd-grid.slang
+++ b/handheld/console-border/shader-files/lcd-cgwg/lcd-grid.slang
@@ -57,41 +57,48 @@ float intsmear(float x, float dx)
 
 void main()
 {
-  vec2 texelSize = global.SourceSize.zw;
-  vec2 subtexelSize = texelSize / vec2(3.0,1.0);
-  vec2 range;
-  range = global.SourceSize.zw / screen_scale;
-  
-  float left   = vTexCoord.x - texelSize.x*0.5;
-  float top    = vTexCoord.y + range.y;
-  float right  = vTexCoord.x + texelSize.x*0.5;
-  float bottom = vTexCoord.y - range.y;
-  
-  vec4 lcol, rcol;
-  float subpix = mod(vTexCoord.x/subtexelSize.x+1.5,3.0);
-  float rsubpix = range.x/subtexelSize.x;
-  lcol = vec4(intsmear(subpix+1.0,rsubpix),intsmear(subpix    ,rsubpix),
-	      intsmear(subpix-1.0,rsubpix),0.0);
-  rcol = vec4(intsmear(subpix-2.0,rsubpix),intsmear(subpix-3.0,rsubpix),
-	      intsmear(subpix-4.0,rsubpix),0.0);
-			  
-  vec4 topLeftColor     = TEX2D((floor(vec2(left, top)     / texelSize) + 0.5) * texelSize) * lcol;
-  vec4 bottomRightColor = TEX2D((floor(vec2(right, bottom) / texelSize) + 0.5) * texelSize) * rcol;
-  vec4 bottomLeftColor  = TEX2D((floor(vec2(left, bottom)  / texelSize) + 0.5) * texelSize) * lcol;
-  vec4 topRightColor    = TEX2D((floor(vec2(right, top)    / texelSize) + 0.5) * texelSize) * rcol;
-  
-  vec2 border = round(vTexCoord.st/subtexelSize);
-  vec2 bordert = clamp((border+vec2(0.0,+global.GRID_STRENGTH)) * subtexelSize,
-		       vec2(left, bottom), vec2(right, top));
-  vec2 borderb = clamp((border+vec2(0.0,-global.GRID_STRENGTH)) * subtexelSize,
-		       vec2(left, bottom), vec2(right, top));
-  float totalArea = 2.0 * range.y;  
+  if(abs(vTexCoord.x - 0.5) < 0.5 && abs(vTexCoord.y - 0.5) < 0.5)
+  {
+    vec2 texelSize = global.SourceSize.zw;
+    vec2 subtexelSize = texelSize / vec2(3.0,1.0);
+    vec2 range;
+    range = global.SourceSize.zw / screen_scale;
+    
+    float left   = vTexCoord.x - texelSize.x*0.5;
+    float top    = vTexCoord.y + range.y;
+    float right  = vTexCoord.x + texelSize.x*0.5;
+    float bottom = vTexCoord.y - range.y;
+    
+    vec4 lcol, rcol;
+    float subpix = mod(vTexCoord.x/subtexelSize.x+1.5,3.0);
+    float rsubpix = range.x/subtexelSize.x;
+    lcol = vec4(intsmear(subpix+1.0,rsubpix),intsmear(subpix    ,rsubpix),
+          intsmear(subpix-1.0,rsubpix),0.0);
+    rcol = vec4(intsmear(subpix-2.0,rsubpix),intsmear(subpix-3.0,rsubpix),
+          intsmear(subpix-4.0,rsubpix),0.0);
+          
+    vec4 topLeftColor     = TEX2D((floor(vec2(left, top)     / texelSize) + 0.5) * texelSize) * lcol;
+    vec4 bottomRightColor = TEX2D((floor(vec2(right, bottom) / texelSize) + 0.5) * texelSize) * rcol;
+    vec4 bottomLeftColor  = TEX2D((floor(vec2(left, bottom)  / texelSize) + 0.5) * texelSize) * lcol;
+    vec4 topRightColor    = TEX2D((floor(vec2(right, top)    / texelSize) + 0.5) * texelSize) * rcol;
+    
+    vec2 border = round(vTexCoord.st/subtexelSize);
+    vec2 bordert = clamp((border+vec2(0.0,+global.GRID_STRENGTH)) * subtexelSize,
+            vec2(left, bottom), vec2(right, top));
+    vec2 borderb = clamp((border+vec2(0.0,-global.GRID_STRENGTH)) * subtexelSize,
+            vec2(left, bottom), vec2(right, top));
+    float totalArea = 2.0 * range.y;  
 
-   vec4 averageColor;
-  averageColor  = ((top - bordert.y)    / totalArea) * topLeftColor;
-  averageColor += ((borderb.y - bottom) / totalArea) * bottomRightColor;
-  averageColor += ((borderb.y - bottom) / totalArea) * bottomLeftColor;
-  averageColor += ((top - bordert.y)    / totalArea) * topRightColor;
-  
-   FragColor = pow(averageColor,vec4(1.0/global.gamma));
+    vec4 averageColor;
+    averageColor  = ((top - bordert.y)    / totalArea) * topLeftColor;
+    averageColor += ((borderb.y - bottom) / totalArea) * bottomRightColor;
+    averageColor += ((borderb.y - bottom) / totalArea) * bottomLeftColor;
+    averageColor += ((top - bordert.y)    / totalArea) * topRightColor;
+    
+    FragColor = pow(averageColor,vec4(1.0/global.gamma));
+  }
+  else
+  {
+    FragColor = vec4(0.0);
+  }
 }


### PR DESCRIPTION
The new changes to allow LCD-based shaders to be scaled by a parameter introduced a problem where the processing was being applied to the whole viewport instead of just the game area.
This caused blurriness at the cutoff point and lowered performance.

This fixes it and increases performance.

I don't know why the diff looks huge (probably because I changed the indentation), but in reality the only thing changed was an added if-else block to the whole fragment stage.
This is the added condition:
`if(abs(vTexCoord.x - 0.5) < 0.5 && abs(vTexCoord.y - 0.5) < 0.5)`