### PR TITLE
add parameters to xbrz-freescale and put multipass into a subdirectory

### DIFF
--- a/xbrz/shaders/xbrz-freescale-multipass/xbrz-freescale-pass0.slang
+++ b/xbrz/shaders/xbrz-freescale-multipass/xbrz-freescale-pass0.slang
@@ -46,9 +46,20 @@
 // * do so, delete this exception statement from your version.                *
 // ****************************************************************************
 
-#define BLEND_NONE 0
-#define BLEND_NORMAL 1
-#define BLEND_DOMINANT 2
+layout(push_constant) uniform Push
+{
+	vec4 SourceSize;
+	vec4 OutputSize;
+	float blend_none, blend_normal, blend_dominant;
+} params;
+
+#pragma parameter blend_none "Blend None" 0.0 0.0 2.0 1.0
+#pragma parameter blend_normal "Blend Normal" 1.0 0.0 2.0 1.0
+#pragma parameter blend_dominant "Blend Dominant" 2.0 0.0 2.0 1.0
+
+#define BLEND_NONE int(params.blend_none)
+#define BLEND_NORMAL int(params.blend_normal)
+#define BLEND_DOMINANT int(params.blend_dominant)
 #define LUMINANCE_WEIGHT 1.0
 #define EQUAL_COLOR_TOLERANCE 30.0/255.0
 #define STEEP_DIRECTION_THRESHOLD 2.2
@@ -84,12 +95,6 @@ float get_left_ratio(vec2 center, vec2 origin, vec2 direction, vec2 scale)
 //  return step(0, v);
   return smoothstep(-sqrt(2.0)/2.0, sqrt(2.0)/2.0, v);
 }
-
-layout(push_constant) uniform Push
-{
-	vec4 SourceSize;
-	vec4 OutputSize;
-} params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
 {

--- a/xbrz/shaders/xbrz-freescale-multipass/xbrz-freescale-pass1.slang
+++ b/xbrz/shaders/xbrz-freescale-multipass/xbrz-freescale-pass1.slang
@@ -43,9 +43,20 @@
 // * do so, delete this exception statement from your version.                *
 // ****************************************************************************
 
-#define BLEND_NONE 0
-#define BLEND_NORMAL 1
-#define BLEND_DOMINANT 2
+layout(push_constant) uniform Push
+{
+	vec4 xbrz_fs_refpassSize;
+	vec4 OutputSize;
+	float blend_none, blend_normal, blend_dominant;
+} params;
+
+#pragma parameter blend_none "Blend None" 0.0 0.0 2.0 1.0
+#pragma parameter blend_normal "Blend Normal" 1.0 0.0 2.0 1.0
+#pragma parameter blend_dominant "Blend Dominant" 2.0 0.0 2.0 1.0
+
+#define BLEND_NONE int(params.blend_none)
+#define BLEND_NORMAL int(params.blend_normal)
+#define BLEND_DOMINANT int(params.blend_dominant)
 #define LUMINANCE_WEIGHT 1.0
 #define EQUAL_COLOR_TOLERANCE 30.0/255.0
 #define STEEP_DIRECTION_THRESHOLD 2.2
@@ -81,12 +92,6 @@ float get_left_ratio(vec2 center, vec2 origin, vec2 direction, vec2 scale)
 //  return step(0, v);
   return smoothstep(-sqrt(2.0)/2.0, sqrt(2.0)/2.0, v);
 }
-
-layout(push_constant) uniform Push
-{
-	vec4 xbrz_fs_refpassSize;
-	vec4 OutputSize;
-} params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
 {

--- a/xbrz/shaders/xbrz-freescale.slang
+++ b/xbrz/shaders/xbrz-freescale.slang
@@ -46,9 +46,20 @@
 // * do so, delete this exception statement from your version.                *
 // ****************************************************************************
 
-#define BLEND_NONE 0
-#define BLEND_NORMAL 1
-#define BLEND_DOMINANT 2
+layout(push_constant) uniform Push
+{
+	vec4 SourceSize;
+	vec4 OutputSize;
+	float blend_none, blend_normal, blend_dominant;
+} params;
+
+#pragma parameter blend_none "Blend None" 0.0 0.0 2.0 1.0
+#pragma parameter blend_normal "Blend Normal" 1.0 0.0 2.0 1.0
+#pragma parameter blend_dominant "Blend Dominant" 2.0 0.0 2.0 1.0
+
+#define BLEND_NONE int(params.blend_none)
+#define BLEND_NORMAL int(params.blend_normal)
+#define BLEND_DOMINANT int(params.blend_dominant)
 #define LUMINANCE_WEIGHT 1.0
 #define EQUAL_COLOR_TOLERANCE 30.0/255.0
 #define STEEP_DIRECTION_THRESHOLD 2.2
@@ -84,12 +95,6 @@ float get_left_ratio(vec2 center, vec2 origin, vec2 direction, vec2 scale)
 //  return step(0, v);
   return smoothstep(-sqrt(2.0)/2.0, sqrt(2.0)/2.0, v);
 }
-
-layout(push_constant) uniform Push
-{
-	vec4 SourceSize;
-	vec4 OutputSize;
-} params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
 {

--- a/xbrz/xbrz-freescale-multipass.slangp
+++ b/xbrz/xbrz-freescale-multipass.slangp
@@ -3,12 +3,12 @@ shaders = 3
 shader0 = ../stock.slang
 alias0 = xbrz_fs_refpass
 
-shader1 = shaders/xbrz-freescale-pass0.slang
+shader1 = shaders/xbrz-freescale-multipass/xbrz-freescale-pass0.slang
 filter_linear1 = false
 scale_type1 = source
 scale1 = 1.0
 
-shader2 = shaders/xbrz-freescale-pass1.slang
+shader2 = shaders/xbrz-freescale-multipass/xbrz-freescale-pass1.slang
 filter_linear2 = false
 scale_type2 = viewport
 scale2 = 1.0


### PR DESCRIPTION
Adding these parameters lets users choose how much blending and interpolation happens. For example, setting the normal and dominant parameters to the same value but different from the none parameter rounds all corners.

This change has a small impact on performance--roughly 1-2% in my testing. I had originally parameterized the other macros, which have a more subtle effect, but the performance hit was more like 4-5%, which seemed a bit much for something that not many people are likely to mess with.

This PR alleviates the need for duplicating these shaders in https://github.com/libretro/slang-shaders/pull/344