### PR TITLE
Fix GTU-v50 to function like GLSL/Cg versions

### DIFF
--- a/crt/gtu-v050.slangp
+++ b/crt/gtu-v050.slangp
@@ -10,7 +10,7 @@ scale_type_x1 = viewport
 scale_x1 = 1.0
 scale_type_y1 = source
 scale_y1 = 1.0
-filter_linear1 = true
+filter_linear1 = false
 float_framebuffer1 = true
 
 shader2 = shaders/gtu-v050/pass3.slang

--- a/crt/shaders/gtu-v050/pass2.slang
+++ b/crt/shaders/gtu-v050/pass2.slang
@@ -11,9 +11,18 @@ layout(push_constant) uniform Push
 	float compositeConnection;
 } params;
 
+#pragma parameter compositeConnection "Composite Connection Enable" 0.0 0.0 1.0 1.0
+//#define compositeConnection params.compositeConnection
 #pragma parameter signalResolution "Signal Resolution Y" 256.0 16.0 1024.0 16.0
+//#define signalResolution params.signalResolution
 #pragma parameter signalResolutionI "Signal Resolution I" 83.0 1.0 350.0 2.0
+//#define signalResolutionI params.signalResolutionI
 #pragma parameter signalResolutionQ "Signal Resolution Q" 25.0 1.0 350.0 2.0
+//#define signalResolutionQ params.signalResolutionQ
+
+#define InputSize params.SourceSize
+//#define SourceSize params.SourceSize
+#define COMPAT_TEXTURE(c,d) texture(c,d)
 
 layout(std140, set = 0, binding = 0) uniform UBO
 {
@@ -28,20 +37,20 @@ layout(std140, set = 0, binding = 0) uniform UBO
 
 #include "config.h"
 
-#define YIQ_to_RGB 	mat3x3( 1.0   , 1.0      , 1.0      ,	0.9563   , -0.2721   , -1.1070   ,		0.6210   , -0.6474   , 1.7046   )
+#define YIQ_to_RGB 	mat3( 1.0   , 1.0      , 1.0      ,	0.9563   , -0.2721   , -1.1070   ,		0.6210   , -0.6474   , 1.7046   )
 #define pi        3.14159265358
 #define a(x) abs(x)
 #define d(x,b) (pi*b*min(a(x)+0.5,1.0/b))
 #define e(x,b) (pi*b*min(max(a(x)-0.5,-1.0/b),1.0/b))
 #define STU(x,b) ((d(x,b)+sin(d(x,b))-e(x,b)-sin(e(x,b)))/(2.0*pi))
 //#define X(i) (offset-(i))
-#define GETC (texture(Source, vec2(vTexCoord.x - X * params.SourceSize.z, vTexCoord.y)).rgb)
+#define GETC (COMPAT_TEXTURE(Source, vec2(vTexCoord.x - X * params.SourceSize.z, vTexCoord.y)).rgb)
 
-#define VAL_composite vec3((c.x*STU(X,(params.signalResolution * params.SourceSize.z))),(c.y*STU(X,(params.signalResolutionI * params.SourceSize.z))),(c.z*STU(X,(params.signalResolutionQ * params.SourceSize.z))))
-#define VAL (c*STU(X,(params.signalResolution * params.SourceSize.z)))
+#define VAL_composite vec3((c.x*STU(X,(params.signalResolution  / params.SourceSize.x))),(c.y*STU(X,(params.signalResolutionI / params.SourceSize.x))),(c.z*STU(X,(params.signalResolutionQ / params.SourceSize.x))))
+#define VAL (c*STU(X,(params.signalResolution / params.SourceSize.x)))
 
-#define PROCESS(i) X=(offset-(i));c=GETC;tempColor+=VAL;
-#define PROCESS_composite(i) X=(offset-(i));c=GETC;tempColor+=VAL_composite;
+#define PROCESS(i) X=(i);c=GETC;tempColor+=VAL;
+#define PROCESS_composite(i) X=(i);c=GETC;tempColor+=VAL_composite;
 
 #pragma stage vertex
 layout(location = 0) in vec4 Position;

--- a/crt/shaders/gtu-v050/pass2.slang
+++ b/crt/shaders/gtu-v050/pass2.slang
@@ -12,17 +12,9 @@ layout(push_constant) uniform Push
 } params;
 
 #pragma parameter compositeConnection "Composite Connection Enable" 0.0 0.0 1.0 1.0
-//#define compositeConnection params.compositeConnection
 #pragma parameter signalResolution "Signal Resolution Y" 256.0 16.0 1024.0 16.0
-//#define signalResolution params.signalResolution
 #pragma parameter signalResolutionI "Signal Resolution I" 83.0 1.0 350.0 2.0
-//#define signalResolutionI params.signalResolutionI
 #pragma parameter signalResolutionQ "Signal Resolution Q" 25.0 1.0 350.0 2.0
-//#define signalResolutionQ params.signalResolutionQ
-
-#define InputSize params.SourceSize
-//#define SourceSize params.SourceSize
-#define COMPAT_TEXTURE(c,d) texture(c,d)
 
 layout(std140, set = 0, binding = 0) uniform UBO
 {
@@ -43,8 +35,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define d(x,b) (pi*b*min(a(x)+0.5,1.0/b))
 #define e(x,b) (pi*b*min(max(a(x)-0.5,-1.0/b),1.0/b))
 #define STU(x,b) ((d(x,b)+sin(d(x,b))-e(x,b)-sin(e(x,b)))/(2.0*pi))
-//#define X(i) (offset-(i))
-#define GETC (COMPAT_TEXTURE(Source, vec2(vTexCoord.x - X * params.SourceSize.z, vTexCoord.y)).rgb)
+#define GETC (texture(Source, vec2(vTexCoord.x - X * params.SourceSize.z, vTexCoord.y)).rgb)
 
 #define VAL_composite vec3((c.x*STU(X,(params.signalResolution  / params.SourceSize.x))),(c.y*STU(X,(params.signalResolutionI / params.SourceSize.x))),(c.z*STU(X,(params.signalResolutionQ / params.SourceSize.x))))
 #define VAL (c*STU(X,(params.signalResolution / params.SourceSize.x)))
@@ -96,6 +87,5 @@ void main()
    else
       tempColor=clamp(tempColor,0.0,1.0);
 
-   // tempColor=clamp(tempColor,0.0,1.0);
    FragColor = vec4(tempColor, 1.0);
 }


### PR DESCRIPTION
As pointed out by zaksdf on reddit, the slang version was leaning on bilinear filtering in a way that was incorrect. I'm not sure why the GLSL version was unaffected, since it was _ported from the slang version_, but nevertheless, this should get it fixed up.