### PR TITLE
 V5.5 Sony Megatron Shader

### DIFF
--- a/hdr/shaders/crt-sony-megatron-source-pass.slang
+++ b/hdr/shaders/crt-sony-megatron-source-pass.slang
@@ -35,11 +35,13 @@ layout(push_constant) uniform Push
    float hcrt_lcd_subpixel;
    float hcrt_colour_system;
    float hcrt_expand_gamut;
-   float hcrt_white_temperature;
+   float hcrt_white_temperature_D65;
+   float hcrt_white_temperature_D93;
    float hcrt_brightness;
    float hcrt_contrast;
    float hcrt_saturation;
    float hcrt_gamma_in;
+   float hcrt_gamma_cutoff;
    float hcrt_colour_accurate;
 } params;
 
@@ -57,11 +59,13 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_HDR                            params.hcrt_hdr
 #define HCRT_OUTPUT_COLOUR_SPACE            params.hcrt_colour_space
 #define HCRT_CRT_COLOUR_SYSTEM              params.hcrt_colour_system
-#define HCRT_WHITE_TEMPERATURE              params.hcrt_white_temperature
+#define HCRT_WHITE_TEMPERATURE_D65          params.hcrt_white_temperature_D65
+#define HCRT_WHITE_TEMPERATURE_D93          params.hcrt_white_temperature_D93
 #define HCRT_BRIGHTNESS                     params.hcrt_brightness
 #define HCRT_CONTRAST                       params.hcrt_contrast
 #define HCRT_SATURATION                     params.hcrt_saturation
 #define HCRT_GAMMA_IN                       params.hcrt_gamma_in
+#define HCRT_GAMMA_CUTOFF                   params.hcrt_gamma_cutoff
 #define HCRT_COLOUR_ACCURATE                params.hcrt_colour_accurate
 
 #define COMPAT_TEXTURE(c, d) texture(c, d)

--- a/hdr/shaders/crt-sony-megatron.slang
+++ b/hdr/shaders/crt-sony-megatron.slang
@@ -33,7 +33,7 @@ layout(push_constant) uniform Push
    float hcrt_max_nits;
    float hcrt_paper_white_nits;
    float hcrt_expand_gamut;
-   float hcrt_gamma_out;
+   
    float hcrt_colour_accurate;
 
    float hcrt_lcd_resolution;
@@ -79,6 +79,12 @@ layout(std140, set = 0, binding = 0) uniform UBO
 	vec4 OutputSize;
 	uint FrameCount;
 
+   float hcrt_r709_gamma_out;
+   float hcrt_srgb_gamma_out;
+   float hcrt_p3_gamma_out;
+   float hcrt_r709_gamma_cutoff;
+   float hcrt_srgb_gamma_cutoff;
+
    float hcrt_h_size;
    float hcrt_v_size;
    float hcrt_h_cent;
@@ -94,7 +100,11 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_MAX_NITS                        params.hcrt_max_nits
 #define HCRT_PAPER_WHITE_NITS                params.hcrt_paper_white_nits
 #define HCRT_EXPAND_GAMUT                    params.hcrt_expand_gamut
-#define HCRT_GAMMA_OUT                       params.hcrt_gamma_out
+#define HCRT_R709_GAMMA_OUT                  global.hcrt_r709_gamma_out
+#define HCRT_SRGB_GAMMA_OUT                  global.hcrt_srgb_gamma_out
+#define HCRT_P3_GAMMA_OUT                    global.hcrt_p3_gamma_out
+#define HCRT_R709_GAMMA_CUTOFF               global.hcrt_r709_gamma_cutoff
+#define HCRT_SRGB_GAMMA_CUTOFF               global.hcrt_srgb_gamma_cutoff
 #define HCRT_COLOUR_ACCURATE                 params.hcrt_colour_accurate
 
 #define HCRT_LCD_RESOLUTION                  params.hcrt_lcd_resolution 

--- a/hdr/shaders/include/gamma_correct.h
+++ b/hdr/shaders/include/gamma_correct.h
@@ -14,8 +14,7 @@ const mat3 kXYZ_to_DCIP3 = mat3 (
 
 float LinearTosRGB_1(const float channel)
 {
-	//return (channel > 0.0031308f) ? (1.055f * pow(channel, 1.0f / HCRT_GAMMA_OUT)) - 0.055f : channel * 12.92f; 
-   return (1.055f * pow(channel, 1.0f / HCRT_GAMMA_OUT)) - 0.055f; 
+	return (channel > (HCRT_SRGB_GAMMA_CUTOFF * (1.0f / 1000.0f))) ? (1.055f * pow(channel, 1.0f / HCRT_SRGB_GAMMA_OUT)) - 0.055f : channel * 12.92f; 
 }
 
 vec3 LinearTosRGB(const vec3 colour)
@@ -25,8 +24,7 @@ vec3 LinearTosRGB(const vec3 colour)
 
 float LinearTo709_1(const float channel)
 {
-	//return (channel >= 0.018f) ? pow(channel * 1.099f, 1.0f / (HCRT_GAMMA_OUT - 0.18f)) - 0.099f : channel * 4.5f;  // Gamma: 2.4 - 0.18 = 2.22
-   return pow(channel * 1.099f, 1.0f / (HCRT_GAMMA_OUT - 0.18f)) - 0.099f;
+	return (channel >= (HCRT_R709_GAMMA_CUTOFF * (1.0f / 1000.0f))) ? pow(channel * 1.099f, 1.0f / HCRT_R709_GAMMA_OUT) - 0.099f : channel * 4.5f;
 }
 
 vec3 LinearTo709(const vec3 colour)
@@ -36,7 +34,7 @@ vec3 LinearTo709(const vec3 colour)
 
 float LinearToDCIP3_1(const float channel)
 {
-	return pow(channel, 1.0f / (HCRT_GAMMA_OUT + 0.2f));   // Gamma: 2.4 + 0.2 = 2.6
+	return pow(channel, 1.0f / HCRT_P3_GAMMA_OUT);
 }
 
 vec3 LinearToDCIP3(const vec3 colour)

--- a/hdr/shaders/include/parameters.h
+++ b/hdr/shaders/include/parameters.h
@@ -7,34 +7,43 @@
 #pragma parameter hcrt_support0                      "SDR mode: Turn up your TV's brightness as high as possible"   0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_support1                      "HDR mode: Set the peak luminance to that of your TV."         0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_support2                      "Then adjust paper white luminance until it looks right"       0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_support3                      " "                                                            0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_support4                      "Default white points for the different colour systems:"       0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_support5                      "709: 6500K, PAL: 6500K, NTSC-U: 6500K, NTSC-J: 9300K"         0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_space1                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support3                      "Default white points for the different colour systems:"       0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support4                      "709: D65, PAL: D65, NTSC-U: D65, NTSC-J: D93"         		0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space2                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support5                      "Rec. 709 gamma cutoff is 0.018 x 1000 = 18"       			0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support6                      "sRGB gamma cutoff is 0.0031308 x 1000 = ~31"       			0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support7                      "Rec. 601/709 inverse gamma cutoff is 0.081 x 1000 = 81"       0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_user_settings                 "YOUR DISPLAY'S SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_hdr                           "    SDR | HDR"                                                1.0      0.0   1.0      1.0
 #pragma parameter hcrt_colour_accurate               "    Mask Accurate/Colour Accurate"                            1.0      0.0   1.0      1.0
 #pragma parameter hcrt_colour_space                  "    SDR: Display's Colour Space: r709 | sRGB | DCI-P3"        1.0      0.0   2.0      1.0
-#pragma parameter hcrt_gamma_out                     "    SDR: Gamma"                                               2.4      1.0   5.0      0.01
+#pragma parameter hcrt_r709_gamma_out                "    SDR: r709 Gamma"                                          2.22     1.0   5.0      0.01
+#pragma parameter hcrt_srgb_gamma_out                "    SDR: sRGB Gamma"                                          2.4      1.0   5.0      0.01
+#pragma parameter hcrt_p3_gamma_out                  "    SDR: DCI-P3 Gamma"                                        2.6      1.0   5.0      0.01
+#pragma parameter hcrt_r709_gamma_cutoff             "    SDR: r709 Gamma Cutoff (x1000)"                           1.0      0.0   100.0    1.00
+#pragma parameter hcrt_srgb_gamma_cutoff             "    SDR: sRGB Gamma Cutoff (x1000)"                           1.0      0.0   100.0    1.00
 #pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                            1000.0   0.0   10000.0  10.0
 #pragma parameter hcrt_paper_white_nits              "    HDR: Display's Paper White Luminance"                     200.0    0.0   10000.0  10.0
 #pragma parameter hcrt_expand_gamut                  "    HDR: Original/Vivid"                                      0.0      0.0   1.0      1.0
 #pragma parameter hcrt_lcd_resolution                "    Display's Resolution: 1080p | 4K | 8K"                    1.0      0.0   2.0      1.0
 #pragma parameter hcrt_lcd_subpixel                  "    Display's Subpixel Layout: RGB | RWBG (OLED) | BGR"       0.0      0.0   2.0      1.0
-#pragma parameter hcrt_space2                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space4                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings            "CRT SETTINGS:"                                                0.0      0.0   0.0001   0.0001
-//#pragma parameter hcrt_crt_screen_type               "    Screen Type: APERTURE GRILLE | SHADOW MASK | SLOT MASK"   0.0      0.0   3.0      1.0
 #pragma parameter hcrt_crt_screen_type               "    Screen Type: APERTURE GRILLE | SHADOW MASK | SLOT MASK"   0.0      0.0   2.0      1.0
 #pragma parameter hcrt_crt_resolution                "    Resolution: 300TVL | 600TVL | 800TVL | 1000TVL"           1.0      0.0   3.0      1.0
 #pragma parameter hcrt_colour_system                 "    Colour System: r709 | PAL | NTSC-U | NTSC-J"              2.0      0.0   3.0      1.0
-#pragma parameter hcrt_white_temperature             "    White Temperature Offset (Kelvin)"                        0.0     -5000.0  12000.0      100.0
+#pragma parameter hcrt_white_temperature_D65         "    D65 White Temperature (Kelvin)"                    		6504.0   0.0   18500.0  100.0
+#pragma parameter hcrt_white_temperature_D93         "    D93 White Temperature (Kelvin)"                    		9305.0   0.0   18500.0  100.0
 #pragma parameter hcrt_brightness                    "    Brightness"                                               0.0     -1.0   1.0      0.01
 #pragma parameter hcrt_contrast                      "    Contrast"                                                 0.0     -1.0   1.0      0.01
 #pragma parameter hcrt_saturation                    "    Saturation"                                               0.0     -1.0   1.0      0.01
 #pragma parameter hcrt_gamma_in                      "    Gamma"                                                    2.22     1.0   5.0      0.01
+#pragma parameter hcrt_gamma_cutoff                  "    Inverse Gamma Cutoff (x1000)"                             1.0      0.0   100.0    1.0
 #pragma parameter hcrt_pin_phase                     "    Pin Phase"                                                0.00    -0.2   0.2      0.01
 #pragma parameter hcrt_pin_amp                       "    Pin Amp"                                                  0.00    -0.2   0.2      0.01
-#pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space5                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings0           "    VERTICAL SETTINGS:"                                       0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_v_size                        "        Vertical Size"                                        1.00     0.8   1.2      0.01
 #pragma parameter hcrt_v_cent                        "        Vertical Center"                                      0.00  -200.0 200.0      1.0
@@ -50,7 +59,7 @@
 #pragma parameter hcrt_blue_scanline_min             "        Blue Scanline Min"                                    0.50     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_max             "        Blue Scanline Max"                                    1.00     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_attack          "        Blue Scanline Attack"                                 0.20     0.0   1.0      0.01
-#pragma parameter hcrt_space4                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space6                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings1           "    HORIZONTAL SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_h_size                        "        Horizontal Size"                                      1.00     0.8   1.2      0.01
 #pragma parameter hcrt_h_cent                        "        Horizontal Center"                                    0.00  -200.0 200.0      1.0


### PR DESCRIPTION
Reintroduced all the correct OETF and EOTF functions for all the Rec. standards
Added gamma cut off values so people can adjust the gamma switch over point between equations as the standards define Refactored the parameters and broke out values to be more clear