### PR TITLE
newpixie: Don't flip geometry coordinates, flip texcoords.

### DIFF
--- a/crt/shaders/newpixie/newpixie-crt.slang
+++ b/crt/shaders/newpixie/newpixie-crt.slang
@@ -81,9 +81,8 @@ layout(location = 0) out vec2 vTexCoord;
 
 void main()
 {
-   vec4 modpos = vec4(Position.x, 1.-Position.y, Position.z, Position.w);
-   gl_Position = global.MVP * modpos;
-   vTexCoord = TexCoord;
+   gl_Position = global.MVP * Position;
+   vTexCoord = vec2(TexCoord.x, 1.0 - TexCoord.y);
 }
 
 #pragma stage fragment


### PR DESCRIPTION
The spec states:
> This attribute is a 2D position in the form vec4(x, y, 0.0, 1.0);. Shaders should not try to extract meaning from the x, y. gl_Position must be assigned as:
> 
> `gl_Position = MVP * Position;`

Furthermore, the idiomatic way of covering the screen is using an oversized triangle, not two separate triangles like RetroArch does, wherein changing the position doesn't work. Invert the texture coordinate instead.
