### PR TITLE
crt-royale: Fix division by zero when border is 0.

### DIFF
--- a/crt/shaders/crt-royale/src/geometry-functions.h
+++ b/crt/shaders/crt-royale/src/geometry-functions.h
@@ -679,6 +679,8 @@ float get_border_dim_factor(const float2 video_uv, const float2 geom_aspect)
     const float2 border_penetration =
         max(float2(border_size) - edge_dists, float2(0.0));
     const float penetration_ratio = length(border_penetration)/border_size;
+    if (border_size == 0.0)
+        penetration_ratio = 0.0;
     const float border_escape_ratio = max(1.0 - penetration_ratio, 0.0);
     const float border_dim_factor =
         pow(border_escape_ratio, border_darkness) * max(1.0, border_compress);


### PR DESCRIPTION
When border size is 0, a division by zero causes the border to become infinitely large. Special-case this.

This allows removing the border with the seemingly stricter Vulkan implementations. On OpenGL, I'm able to remove the border by setting the border darkness to zero, but that doesn't work with Vulkan, probably because of another NaN or Inf somewhere. This lets you do the logical thing and correctly set the border size to 0 with either API.