### PR TITLE
Koko-aio: Re-enable mipmaps for bezel and wrap_mode in shader.

### DIFF
--- a/bezel/koko-aio/shaders/config.inc
+++ b/bezel/koko-aio/shaders/config.inc
@@ -3,7 +3,7 @@
 
 	// Uncomment this to improve bezel downscaling.
 	// If you are using standard bezel, leave commented to gain performance.
-//#define STATIC_BEZEL_USE_MIPMAP 1.0
+#define STATIC_BEZEL_USE_MIPMAP 1.0
 
 	//This is used to skip calculations in the reflection blur code.
 	//set it to minimum value that allows you to see reflection entirely
@@ -126,7 +126,7 @@
 
 	//Should texture wrapping be allowed as a shader parameter?
 	//since it causes branching, better set it as a static value.
-//#define ALLOW_BG_IMAGE_TEXTURE_WRAP_IN_SHADER
+#define ALLOW_BG_IMAGE_TEXTURE_WRAP_IN_SHADER
 
 
 	//Gap size in pixel for 1X to 4X mask scaling:
@@ -517,8 +517,7 @@ layout(std140, set = 0, binding = 0) uniform UBO {
 #pragma parameter BG_IMAGE_ZOOM	     "        Zoom Image"					 1.0  -1.0  3.0    0.0005
 #pragma parameter BG_IMAGE_ROTATION  "        Rotate image mode (-1 for auto)"	     		 -1.0  -1.0  2.0    1.0
 #pragma parameter BG_IMAGE_NIGHTIFY  "        Nightify image"                                 0.0   0.0  1.0    0.1
-#pragma parameter LABEL_0101         "        !NEXT FEATURE IS STATIC, SEE docs.md TO ENABLE"    0.0 0.0 1.0 1.0
-#pragma parameter BG_IMAGE_WRAP_MODE "            Wrap mode: default, clamp to border, edge, repeat" 0.0  0.0    3.0    1.0
+#pragma parameter BG_IMAGE_WRAP_MODE "        Wrap mode: default, clamp to border, edge, repeat" 0.0  0.0    3.0    1.0
 #pragma parameter BLANK16 " " 0.0 0.0 1.0 1.0
 
 //Backdrop image


### PR DESCRIPTION
The first corrects a glitch on amd+vulkan and the second seems still needed by preset creators