### PR TITLE
Fix broken shader paths for dual filter presets

### DIFF
--- a/blurs/dual_filter_2_pass.slangp
+++ b/blurs/dual_filter_2_pass.slangp
@@ -7,7 +7,7 @@ scale_x0 = 1.0
 scale_y0 = 1.0
 float_framebuffer0 = true
 
-shader1 = shaders/dual_filter_downsample.slang
+shader1 = shaders/dual_filter/downsample.slang
 filter_linear1 = true
 scale_type1 = source
 scale_x1 = 0.5
@@ -15,7 +15,7 @@ scale_y1 = 0.5
 float_framebuffer1 = true
 wrap_mode1 = mirrored_repeat
 
-shader2 = shaders/dual_filter_upsample.slang
+shader2 = shaders/dual_filter/upsample.slang
 filter_linear2 = true
 scale_type2 = source
 scale_x2 = 2.0

--- a/blurs/dual_filter_4_pass.slangp
+++ b/blurs/dual_filter_4_pass.slangp
@@ -7,7 +7,7 @@ scale_x0 = 1.0
 scale_y0 = 1.0
 float_framebuffer0 = true
 
-shader1 = shaders/dual_filter_downsample.slang
+shader1 = shaders/dual_filter/downsample.slang
 filter_linear1 = true
 scale_type1 = source
 scale_x1 = 0.5
@@ -15,7 +15,7 @@ scale_y1 = 0.5
 float_framebuffer1 = true
 wrap_mode1 = mirrored_repeat
 
-shader2 = shaders/dual_filter_downsample.slang
+shader2 = shaders/dual_filter/downsample.slang
 filter_linear2 = true
 scale_type2 = source
 scale_x2 = 0.5
@@ -23,7 +23,7 @@ scale_y2 = 0.5
 float_framebuffer2 = true
 wrap_mode2 = mirrored_repeat
 
-shader3 = shaders/dual_filter_upsample.slang
+shader3 = shaders/dual_filter/upsample.slang
 filter_linear3 = true
 scale_type3 = source
 scale_x3 = 2.0
@@ -31,7 +31,7 @@ scale_y3 = 2.0
 float_framebuffer3 = true
 wrap_mode3 = mirrored_repeat
 
-shader4 = shaders/dual_filter_upsample.slang
+shader4 = shaders/dual_filter/upsample.slang
 filter_linear4 = true
 scale_type4 = source
 scale_x4 = 2.0

--- a/blurs/dual_filter_6_pass.slangp
+++ b/blurs/dual_filter_6_pass.slangp
@@ -7,7 +7,7 @@ scale_x0 = 1.0
 scale_y0 = 1.0
 float_framebuffer0 = true
 
-shader1 = shaders/dual_filter_downsample.slang
+shader1 = shaders/dual_filter/downsample.slang
 filter_linear1 = true
 scale_type1 = source
 scale_x1 = 0.5
@@ -15,7 +15,7 @@ scale_y1 = 0.5
 float_framebuffer1 = true
 wrap_mode1 = mirrored_repeat
 
-shader2 = shaders/dual_filter_downsample.slang
+shader2 = shaders/dual_filter/downsample.slang
 filter_linear2 = true
 scale_type2 = source
 scale_x2 = 0.5
@@ -23,7 +23,7 @@ scale_y2 = 0.5
 float_framebuffer2 = true
 wrap_mode2 = mirrored_repeat
 
-shader3 = shaders/dual_filter_downsample.slang
+shader3 = shaders/dual_filter/downsample.slang
 filter_linear3 = true
 scale_type3 = source
 scale_x3 = 0.5
@@ -31,7 +31,7 @@ scale_y3 = 0.5
 float_framebuffer3 = true
 wrap_mode3 = mirrored_repeat
 
-shader4 = shaders/dual_filter_upsample.slang
+shader4 = shaders/dual_filter/upsample.slang
 filter_linear4 = true
 scale_type4 = source
 scale_x4 = 2.0
@@ -39,7 +39,7 @@ scale_y4 = 2.0
 float_framebuffer4 = true
 wrap_mode4 = mirrored_repeat
 
-shader5 = shaders/dual_filter_upsample.slang
+shader5 = shaders/dual_filter/upsample.slang
 filter_linear5 = true
 scale_type5 = source
 scale_x5 = 2.0
@@ -47,7 +47,7 @@ scale_y5 = 2.0
 float_framebuffer5 = true
 wrap_mode5 = mirrored_repeat
 
-shader6 = shaders/dual_filter_upsample.slang
+shader6 = shaders/dual_filter/upsample.slang
 filter_linear6 = true
 scale_type6 = source
 scale_x6 = 2.0


### PR DESCRIPTION
They were broken during adding the bloom shader when I refactored the file names and file structure.