### PR TITLE
Fix bug with glcore driver of blur fill shader

### DIFF
--- a/border/shaders/blur_fill/compose.slang
+++ b/border/shaders/blur_fill/compose.slang
@@ -27,6 +27,7 @@
     strength of the blur.
 
     Changelog:
+    v1.1: Fix bug with glcore driver.
     v1.0: Initial release.
 */
 

--- a/border/shaders/blur_fill/parameters.slang
+++ b/border/shaders/blur_fill/parameters.slang
@@ -1,7 +1,7 @@
 // See compose.slang for copyright and other information.
 
 // clang-format off
-#pragma parameter BLUR_FILL_SETTINGS "=== Blur fill v1.0 settings ===" 0.0 0.0 1.0 1.0
+#pragma parameter BLUR_FILL_SETTINGS "=== Blur fill v1.1 settings ===" 0.0 0.0 1.0 1.0
 #pragma parameter OS_CROP_TOP "Overscan crop top" 0.0 0.0 1024.0 1.0
 #pragma parameter OS_CROP_BOTTOM "Overscan crop bottom" 0.0 0.0 1024.0 1.0
 #pragma parameter OS_CROP_LEFT "Overscan crop left" 0.0 0.0 1024.0 1.0

--- a/border/shaders/blur_fill/render_sampling_areas.slang
+++ b/border/shaders/blur_fill/render_sampling_areas.slang
@@ -43,12 +43,12 @@ layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Input;
 
-float min(vec4 i) { return min(min(i.x, i.y), min(i.z, i.w)); }
+float min_of_vec4(vec4 i) { return min(min(i.x, i.y), min(i.z, i.w)); }
 
 int argmin(vec4 i) {
-    const vec4 m = vec4(min(i));
+    const vec4 m = vec4(min_of_vec4(i));
     const vec4 ma = step(i, m) * vec4(0.0, -1.0, -2.0, -3.0);
-    return -int(min(ma));
+    return -int(min_of_vec4(ma));
 }
 
 // Returns a coordinate in [0, w) when repeating that interval (and optionally


### PR DESCRIPTION
The glcore slang compiler did not seem to like the overload of `min()`, so I changed the function to a different name to disambiguate.