### PR TITLE
V5.6 Sony Megatron Shader

### DIFF
--- a/hdr/shaders/crt-sony-megatron-source-pass.slang
+++ b/hdr/shaders/crt-sony-megatron-source-pass.slang
@@ -34,6 +34,7 @@ layout(push_constant) uniform Push
    float hcrt_lcd_resolution;
    float hcrt_lcd_subpixel;
    float hcrt_colour_system;
+   float hcrt_phosphor_set;
    float hcrt_expand_gamut;
    float hcrt_white_temperature_D65;
    float hcrt_white_temperature_D93;
@@ -59,6 +60,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_HDR                            params.hcrt_hdr
 #define HCRT_OUTPUT_COLOUR_SPACE            params.hcrt_colour_space
 #define HCRT_CRT_COLOUR_SYSTEM              params.hcrt_colour_system
+#define HCRT_CRT_PHOSPHOR_SET               params.hcrt_phosphor_set
 #define HCRT_WHITE_TEMPERATURE_D65          params.hcrt_white_temperature_D65
 #define HCRT_WHITE_TEMPERATURE_D93          params.hcrt_white_temperature_D93
 #define HCRT_BRIGHTNESS                     params.hcrt_brightness

--- a/hdr/shaders/include/colour_grade.h
+++ b/hdr/shaders/include/colour_grade.h
@@ -1,11 +1,14 @@
 
 #define kColourSystems  4
+#define kPhosphorSets   5
 
 #define kD50            5003.0f
 #define kD55            5503.0f
 #define kD65            6504.0f
 #define kD75            7504.0f
 #define kD93            9305.0f
+
+// Input Colour Standards
 
 const mat3 k709_to_XYZ = mat3(
    0.412391f, 0.357584f, 0.180481f,
@@ -22,6 +25,40 @@ const mat3 kNTSC_to_XYZ = mat3(
    0.212376f, 0.701060f, 0.086564f,
    0.018739f, 0.111934f, 0.958385f);
 
+// Phosphor Sets - These override the colour standards above when used
+
+// NTSC-J P22
+const mat3 kNTSCJ_P22_to_XYZ = mat3(
+   0.458432f, 0.309549f, 0.182474f,
+   0.256722f, 0.668848f, 0.074430f,
+   0.018337f, 0.127136f, 0.943584f);
+
+//P22 (80’s)
+const mat3 kP2280_to_XYZ = mat3(
+   0.460844f, 0.307613f, 0.181910f,
+   0.244311f, 0.676311f, 0.079378f,
+   0.007123f, 0.106901f, 0.975034f);
+
+//P22 (90’s/tinted phosphors)
+const mat3 kP2290_to_XYZ = mat3(
+   0.404151f, 0.354887f, 0.191418f,
+   0.201984f, 0.714530f, 0.083485f,
+   0.000607f, 0.062960f, 1.025491f);
+
+//RPTV (late 90’s/early 00’s)
+const mat3 kRPTV00_to_XYZ = mat3(
+   0.331718f, 0.429476f, 0.189261f,
+   0.173634f, 0.738044f, 0.088322f,
+   0.012958f, 0.091941f, 0.984159f);
+
+//  NTSC-FCC 1953 Standard Phosphor
+const mat3 k1953_to_XYZ = mat3(
+   0.588010f, 0.179133f, 0.183224f,
+   0.289661f, 0.605640f, 0.104699f,
+   0.000000f, 0.068241f, 1.020817f);
+
+// Output Colour Standards
+
 const mat3 kXYZ_to_709 = mat3(
     3.240970f, -1.537383f, -0.498611f,
    -0.969244f,  1.875968f,  0.041555f,
@@ -32,7 +69,8 @@ const mat3 kXYZ_to_DCIP3 = mat3 (
    -0.8294889696f,  1.7626640603f,  0.0236246858f,
     0.0358458302f, -0.0761723893f,  0.9568845240f);   
 
-const mat3 kColourGamut[kColourSystems] = { k709_to_XYZ, kPAL_to_XYZ, kNTSC_to_XYZ, kNTSC_to_XYZ };
+const mat3 kStandardsColourGamut[kColourSystems] = { k709_to_XYZ, kPAL_to_XYZ, kNTSC_to_XYZ, kNTSC_to_XYZ };
+const mat3 kPhosphorColourGamut[kPhosphorSets] = { kNTSCJ_P22_to_XYZ, kP2280_to_XYZ, kP2290_to_XYZ, kRPTV00_to_XYZ, k1953_to_XYZ };
 
 //const float kTemperatures[kColourSystems] = { kD65, kD65, kD65, kD93 }; 
 
@@ -160,6 +198,7 @@ vec3 BrightnessContrastSaturation(const vec3 xyz)
 vec3 ColourGrade(const vec3 colour)
 {
    const uint colour_system   = uint(HCRT_CRT_COLOUR_SYSTEM);
+   const uint phosphor_set    = uint(HCRT_CRT_PHOSPHOR_SET);
 
    const float temperature[kColourSystems] = { HCRT_WHITE_TEMPERATURE_D65, HCRT_WHITE_TEMPERATURE_D65, HCRT_WHITE_TEMPERATURE_D65, HCRT_WHITE_TEMPERATURE_D93 };
 
@@ -167,7 +206,7 @@ vec3 ColourGrade(const vec3 colour)
 
    const vec3 linear          = r601r709ToLinear(white_point); //pow(white_point, vec3(HCRT_GAMMA_IN));
 
-   const vec3 xyz             = linear * kColourGamut[colour_system];
+   const vec3 xyz             = phosphor_set == 0 ? linear * kStandardsColourGamut[colour_system] : linear * kPhosphorColourGamut[phosphor_set - 1];
 
    const vec3 graded          = BrightnessContrastSaturation(xyz); 
 

--- a/hdr/shaders/include/parameters.h
+++ b/hdr/shaders/include/parameters.h
@@ -1,7 +1,3 @@
-
-
-
-
 #pragma parameter hcrt_title                         "SONY MEGATRON COLOUR VIDEO MONITOR"                           0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_space0                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_support0                      "SDR mode: Turn up your TV's brightness as high as possible"   0.0      0.0   0.0001   0.0001
@@ -17,23 +13,27 @@
 #pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_user_settings                 "YOUR DISPLAY'S SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_hdr                           "    SDR | HDR"                                                1.0      0.0   1.0      1.0
-#pragma parameter hcrt_colour_accurate               "    Mask Accurate/Colour Accurate"                            1.0      0.0   1.0      1.0
+#pragma parameter hcrt_space4                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                            1000.0   0.0   10000.0  10.0
+#pragma parameter hcrt_paper_white_nits              "    HDR: Display's Paper White Luminance"                     200.0    0.0   10000.0  10.0
+#pragma parameter hcrt_expand_gamut                  "    HDR: Original/Vivid"                                      0.0      0.0   1.0      1.0
+#pragma parameter hcrt_space5                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_colour_space                  "    SDR: Display's Colour Space: r709 | sRGB | DCI-P3"        1.0      0.0   2.0      1.0
 #pragma parameter hcrt_r709_gamma_out                "    SDR: r709 Gamma"                                          2.22     1.0   5.0      0.01
 #pragma parameter hcrt_srgb_gamma_out                "    SDR: sRGB Gamma"                                          2.4      1.0   5.0      0.01
 #pragma parameter hcrt_p3_gamma_out                  "    SDR: DCI-P3 Gamma"                                        2.6      1.0   5.0      0.01
 #pragma parameter hcrt_r709_gamma_cutoff             "    SDR: r709 Gamma Cutoff (x1000)"                           1.0      0.0   100.0    1.00
 #pragma parameter hcrt_srgb_gamma_cutoff             "    SDR: sRGB Gamma Cutoff (x1000)"                           1.0      0.0   100.0    1.00
-#pragma parameter hcrt_max_nits                      "    HDR: Display's Peak Luminance"                            1000.0   0.0   10000.0  10.0
-#pragma parameter hcrt_paper_white_nits              "    HDR: Display's Paper White Luminance"                     200.0    0.0   10000.0  10.0
-#pragma parameter hcrt_expand_gamut                  "    HDR: Original/Vivid"                                      0.0      0.0   1.0      1.0
+#pragma parameter hcrt_space6                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_lcd_resolution                "    Display's Resolution: 1080p | 4K | 8K"                    1.0      0.0   2.0      1.0
 #pragma parameter hcrt_lcd_subpixel                  "    Display's Subpixel Layout: RGB | RWBG (OLED) | BGR"       0.0      0.0   2.0      1.0
-#pragma parameter hcrt_space4                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_colour_accurate               "    Mask Accurate/Colour Accurate"                            1.0      0.0   1.0      1.0
+#pragma parameter hcrt_space7                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings            "CRT SETTINGS:"                                                0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_crt_screen_type               "    Screen Type: APERTURE GRILLE | SHADOW MASK | SLOT MASK"   0.0      0.0   2.0      1.0
 #pragma parameter hcrt_crt_resolution                "    Resolution: 300TVL | 600TVL | 800TVL | 1000TVL"           1.0      0.0   3.0      1.0
 #pragma parameter hcrt_colour_system                 "    Colour System: r709 | PAL | NTSC-U | NTSC-J"              2.0      0.0   3.0      1.0
+#pragma parameter hcrt_phosphor_set                  "    Phosphors: NONE | P22-J | P22-80 | P22-90 | RPTV | 1953"  0.0      0.0   5.0      1.0
 #pragma parameter hcrt_white_temperature_D65         "    D65 White Temperature (Kelvin)"                    		6504.0   0.0   18500.0  100.0
 #pragma parameter hcrt_white_temperature_D93         "    D93 White Temperature (Kelvin)"                    		9305.0   0.0   18500.0  100.0
 #pragma parameter hcrt_brightness                    "    Brightness"                                               0.0     -1.0   1.0      0.01
@@ -43,7 +43,7 @@
 #pragma parameter hcrt_gamma_cutoff                  "    Inverse Gamma Cutoff (x1000)"                             1.0      0.0   100.0    1.0
 #pragma parameter hcrt_pin_phase                     "    Pin Phase"                                                0.00    -0.2   0.2      0.01
 #pragma parameter hcrt_pin_amp                       "    Pin Amp"                                                  0.00    -0.2   0.2      0.01
-#pragma parameter hcrt_space5                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space8                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings0           "    VERTICAL SETTINGS:"                                       0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_v_size                        "        Vertical Size"                                        1.00     0.8   1.2      0.01
 #pragma parameter hcrt_v_cent                        "        Vertical Center"                                      0.00  -200.0 200.0      1.0
@@ -59,7 +59,7 @@
 #pragma parameter hcrt_blue_scanline_min             "        Blue Scanline Min"                                    0.50     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_max             "        Blue Scanline Max"                                    1.00     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_attack          "        Blue Scanline Attack"                                 0.20     0.0   1.0      0.01
-#pragma parameter hcrt_space6                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space9                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings1           "    HORIZONTAL SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_h_size                        "        Horizontal Size"                                      1.00     0.8   1.2      0.01
 #pragma parameter hcrt_h_cent                        "        Horizontal Center"                                    0.00  -200.0 200.0      1.0


### PR DESCRIPTION
Added the differing phosphor sets - these override the standards primaries set by the colour system
Moved the settings around a bit to highlight the peak luminance and paper white luminance a bit more 