### PR TITLE
Scaling: Add overscale option

### DIFF
--- a/border/shaders/average_fill/compose.slang
+++ b/border/shaders/average_fill/compose.slang
@@ -41,28 +41,32 @@
 #include "../../../pixel-art-scaling/shaders/pixel_aa/parameters.slang"
 // clang-format on
 
-#include "../../../misc/shaders/scaling.slang"
+#include "../../../misc/shaders/crop_and_scale/crop_and_scale.slang"
 #include "../../../pixel-art-scaling/shaders/pixel_aa/shared.slang"
 
 layout(push_constant) uniform Push {
     vec4 InputSize;
     vec4 OutputSize;
     uint Rotation;
-    float OS_CROP_TOP;
-    float OS_CROP_BOTTOM;
-    float OS_CROP_LEFT;
-    float OS_CROP_RIGHT;
-    float CENTER_AFTER_CROPPING;
-    float SAMPLE_SIZE;
+    // Own settings
     float EXTEND_H;
     float EXTEND_V;
     float CORNER_BLEND_MODE;
+    float FILL_GAMMA;
+    float SAMPLE_SIZE;
+    // From crop and scale, scaling section
     float FORCE_ASPECT_RATIO;
     float ASPECT_H;
     float ASPECT_V;
     float FORCE_INTEGER_SCALING_H;
     float FORCE_INTEGER_SCALING_V;
-    float FILL_GAMMA;
+    float OVERSCALE;
+    // From crop and scale, cropping section
+    float OS_CROP_TOP;
+    float OS_CROP_BOTTOM;
+    float OS_CROP_LEFT;
+    float OS_CROP_RIGHT;
+    float CENTER_AFTER_CROPPING;
     // From pixel AA
     float PIX_AA_SHARP;
     float PIX_AA_SUBPX;
@@ -95,6 +99,7 @@ void main() {
         param.CENTER_AFTER_CROPPING, param.FORCE_ASPECT_RATIO,
         vec2(param.ASPECT_H, param.ASPECT_V),
         vec2(param.FORCE_INTEGER_SCALING_H, param.FORCE_INTEGER_SCALING_V),
+        param.OVERSCALE,
         /* output_size_is_final_viewport_size = */ false);
     tx_coord = o2i(vTexCoord, param.InputSize.xy, crop, param.Rotation,
                    param.CENTER_AFTER_CROPPING, scale_o2i);

--- a/border/shaders/average_fill/compose.slang
+++ b/border/shaders/average_fill/compose.slang
@@ -1,7 +1,7 @@
 #version 450
 
 /*
-    Average fill v1.6 by fishku
+    Average fill v1.7 by fishku
     Copyright (C) 2023
     Public domain license (CC0)
 
@@ -27,6 +27,7 @@
     3 = Smooth angle-based blending
 
     Changelog:
+    v1.7: Add overscale option from crop and scale library.
     v1.6: Refactor for new scaling library. Add rotation support.
     v1.5: Optimize. Update to new Pixel AA version.
     v1.4: Add anti-aliased interpolation for non-integer scaling.

--- a/border/shaders/average_fill/crop_and_sample_common.slang
+++ b/border/shaders/average_fill/crop_and_sample_common.slang
@@ -1,16 +1,18 @@
 // See compose.slang for copyright and other information.
 
-#include "../../../misc/shaders/scaling.slang"
+#include "../../../misc/shaders/crop_and_scale/crop_and_scale.slang"
 #include "parameters.slang"
 
 layout(push_constant) uniform Push {
     vec4 InputSize;
     uint Rotation;
+    // Own settings
+    float SAMPLE_SIZE;
+    // From crop and scale, cropping section
     float OS_CROP_TOP;
     float OS_CROP_BOTTOM;
     float OS_CROP_LEFT;
     float OS_CROP_RIGHT;
-    float SAMPLE_SIZE;
 }
 param;
 

--- a/border/shaders/average_fill/parameters.slang
+++ b/border/shaders/average_fill/parameters.slang
@@ -3,20 +3,7 @@
 // clang-format off
 #pragma parameter AVERAGE_FILL_SETTINGS "=== Average fill v1.6 settings ===" 0.0 0.0 1.0 1.0
 
-#pragma parameter SCALING_SETTINGS "= Scaling parameters =" 0.0 0.0 1.0 1.0
-#pragma parameter FORCE_ASPECT_RATIO "Force aspect ratio" 1.0 0.0 1.0 1.0
-#pragma parameter ASPECT_H "Horizontal aspect ratio before crop (0 = unchanged)" 0.0 0.0 256.0 1.0
-#pragma parameter ASPECT_V "Vertical aspect ratio before crop (0 = unchanged)" 0.0 0.0 256.0 1.0
-#pragma parameter FORCE_INTEGER_SCALING_H "Force integer scaling horizontally" 0.0 0.0 1.0 1.0
-#pragma parameter FORCE_INTEGER_SCALING_V "Force integer scaling vertically" 1.0 0.0 1.0 1.0
-
-#pragma parameter CROPPING_SETTINGS "= Cropping parameters =" 0.0 0.0 1.0 1.0
-#pragma parameter OS_CROP_TOP "Overscan crop top" 0.0 0.0 1024.0 1.0
-#pragma parameter OS_CROP_BOTTOM "Overscan crop bottom" 0.0 0.0 1024.0 1.0
-#pragma parameter OS_CROP_LEFT "Overscan crop left" 0.0 0.0 1024.0 1.0
-#pragma parameter OS_CROP_RIGHT "Overscan crop right" 0.0 0.0 1024.0 1.0
-
-#pragma parameter CENTER_AFTER_CROPPING "Center cropped area" 1.0 0.0 1.0 1.0
+#include "../../../misc/shaders/crop_and_scale/parameters.slang"
 
 #pragma parameter OTHER_SETTINGS "= Other parameters =" 0.0 0.0 1.0 1.0
 #pragma parameter EXTEND_H "Extend the fill horizontally" 1.0 0.0 1.0 1.0

--- a/border/shaders/average_fill/parameters.slang
+++ b/border/shaders/average_fill/parameters.slang
@@ -1,7 +1,7 @@
 // See compose.slang for copyright and other information.
 
 // clang-format off
-#pragma parameter AVERAGE_FILL_SETTINGS "=== Average fill v1.6 settings ===" 0.0 0.0 1.0 1.0
+#pragma parameter AVERAGE_FILL_SETTINGS "=== Average fill v1.7 settings ===" 0.0 0.0 1.0 1.0
 
 #include "../../../misc/shaders/crop_and_scale/parameters.slang"
 

--- a/border/shaders/blur_fill/compose.slang
+++ b/border/shaders/blur_fill/compose.slang
@@ -43,7 +43,7 @@
 #include "../../../pixel-art-scaling/shaders/pixel_aa/parameters.slang"
 // clang-format on
 
-#include "../../../misc/shaders/scaling.slang"
+#include "../../../misc/shaders/crop_and_scale/crop_and_scale.slang"
 #include "../../../pixel-art-scaling/shaders/pixel_aa/shared.slang"
 
 layout(push_constant) uniform Push {
@@ -51,18 +51,22 @@ layout(push_constant) uniform Push {
     vec4 TiledSize;
     vec4 OutputSize;
     uint Rotation;
-    float OS_CROP_TOP;
-    float OS_CROP_BOTTOM;
-    float OS_CROP_LEFT;
-    float OS_CROP_RIGHT;
-    float CENTER_AFTER_CROPPING;
+    // Own settings
+    float FILL_GAMMA;
     float SAMPLE_SIZE;
+    // From crop and scale, scaling section
     float FORCE_ASPECT_RATIO;
     float ASPECT_H;
     float ASPECT_V;
     float FORCE_INTEGER_SCALING_H;
     float FORCE_INTEGER_SCALING_V;
-    float FILL_GAMMA;
+    float OVERSCALE;
+    // From crop and scale, cropping section
+    float OS_CROP_TOP;
+    float OS_CROP_BOTTOM;
+    float OS_CROP_LEFT;
+    float OS_CROP_RIGHT;
+    float CENTER_AFTER_CROPPING;
     // From dual filter blur
     float BLUR_RADIUS;
     // From pixel AA
@@ -94,6 +98,7 @@ void main() {
         param.CENTER_AFTER_CROPPING, param.FORCE_ASPECT_RATIO,
         vec2(param.ASPECT_H, param.ASPECT_V),
         vec2(param.FORCE_INTEGER_SCALING_H, param.FORCE_INTEGER_SCALING_V),
+        param.OVERSCALE,
         /* output_size_is_final_viewport_size = */ false);
     tx_coord = o2i(vTexCoord, param.InputSize.xy, crop, param.Rotation,
                    param.CENTER_AFTER_CROPPING, scale_o2i);

--- a/border/shaders/blur_fill/compose.slang
+++ b/border/shaders/blur_fill/compose.slang
@@ -1,7 +1,7 @@
 #version 450
 
 /*
-    Blur fill v1.7 by fishku
+    Blur fill v1.8 by fishku
     Copyright (C) 2023
     Public domain license (CC0)
 
@@ -27,6 +27,7 @@
     strength of the blur.
 
     Changelog:
+    v1.8: Add overscale option from crop and scale library.
     v1.7: Refactor for new scaling library. Add rotation support.
     v1.6: Optimize. Update to new Pixel AA version. Tune default blur strength.
     v1.5: Add anti-aliased interpolation for non-integer scaling.

--- a/border/shaders/blur_fill/parameters.slang
+++ b/border/shaders/blur_fill/parameters.slang
@@ -3,20 +3,7 @@
 // clang-format off
 #pragma parameter BLUR_FILL_SETTINGS "=== Blur fill v1.7 settings ===" 0.0 0.0 1.0 1.0
 
-#pragma parameter SCALING_SETTINGS "= Scaling parameters =" 0.0 0.0 1.0 1.0
-#pragma parameter FORCE_ASPECT_RATIO "Force aspect ratio" 1.0 0.0 1.0 1.0
-#pragma parameter ASPECT_H "Horizontal aspect ratio before crop (0 = unchanged)" 0.0 0.0 256.0 1.0
-#pragma parameter ASPECT_V "Vertical aspect ratio before crop (0 = unchanged)" 0.0 0.0 256.0 1.0
-#pragma parameter FORCE_INTEGER_SCALING_H "Force integer scaling horizontally" 0.0 0.0 1.0 1.0
-#pragma parameter FORCE_INTEGER_SCALING_V "Force integer scaling vertically" 1.0 0.0 1.0 1.0
-
-#pragma parameter CROPPING_SETTINGS "= Cropping parameters =" 0.0 0.0 1.0 1.0
-#pragma parameter OS_CROP_TOP "Overscan crop top" 0.0 0.0 1024.0 1.0
-#pragma parameter OS_CROP_BOTTOM "Overscan crop bottom" 0.0 0.0 1024.0 1.0
-#pragma parameter OS_CROP_LEFT "Overscan crop left" 0.0 0.0 1024.0 1.0
-#pragma parameter OS_CROP_RIGHT "Overscan crop right" 0.0 0.0 1024.0 1.0
-
-#pragma parameter CENTER_AFTER_CROPPING "Center cropped area" 1.0 0.0 1.0 1.0
+#include "../../../misc/shaders/crop_and_scale/parameters.slang"
 
 #pragma parameter OTHER_SETTINGS "= Other parameters =" 0.0 0.0 1.0 1.0
 #pragma parameter EXTEND_H "Extend the fill horizontally" 0.0 0.0 1.0 1.0

--- a/border/shaders/blur_fill/parameters.slang
+++ b/border/shaders/blur_fill/parameters.slang
@@ -1,7 +1,7 @@
 // See compose.slang for copyright and other information.
 
 // clang-format off
-#pragma parameter BLUR_FILL_SETTINGS "=== Blur fill v1.7 settings ===" 0.0 0.0 1.0 1.0
+#pragma parameter BLUR_FILL_SETTINGS "=== Blur fill v1.8 settings ===" 0.0 0.0 1.0 1.0
 
 #include "../../../misc/shaders/crop_and_scale/parameters.slang"
 

--- a/border/shaders/blur_fill/render_sampling_areas.slang
+++ b/border/shaders/blur_fill/render_sampling_areas.slang
@@ -2,27 +2,31 @@
 
 // See compose.slang for copyright and other information.
 
-#include "../../../misc/shaders/scaling.slang"
+#include "../../../misc/shaders/crop_and_scale/crop_and_scale.slang"
 #include "parameters.slang"
 
 layout(push_constant) uniform Push {
     vec4 InputSize;
     vec4 FinalViewportSize;
     uint Rotation;
-    float OS_CROP_TOP;
-    float OS_CROP_BOTTOM;
-    float OS_CROP_LEFT;
-    float OS_CROP_RIGHT;
-    float CENTER_AFTER_CROPPING;
-    float SAMPLE_SIZE;
+    // Own settings
     float EXTEND_H;
     float EXTEND_V;
     float MIRROR_BLUR;
+    float SAMPLE_SIZE;
+    // From crop and scale, scaling section
     float FORCE_ASPECT_RATIO;
     float ASPECT_H;
     float ASPECT_V;
     float FORCE_INTEGER_SCALING_H;
     float FORCE_INTEGER_SCALING_V;
+    float OVERSCALE;
+    // From crop and scale, cropping section
+    float OS_CROP_TOP;
+    float OS_CROP_BOTTOM;
+    float OS_CROP_LEFT;
+    float OS_CROP_RIGHT;
+    float CENTER_AFTER_CROPPING;
 }
 param;
 
@@ -45,7 +49,7 @@ void main() {
         param.InputSize.xy, param.FinalViewportSize.xy, crop, param.Rotation,
         param.CENTER_AFTER_CROPPING, param.FORCE_ASPECT_RATIO,
         vec2(param.ASPECT_H, param.ASPECT_V),
-        vec2(param.FORCE_INTEGER_SCALING_H, param.FORCE_INTEGER_SCALING_V),
+        vec2(param.FORCE_INTEGER_SCALING_H, param.FORCE_INTEGER_SCALING_V), param.OVERSCALE,
         /* output_size_is_final_viewport_size = */ true);
     tx_coord = o2i(vTexCoord, param.InputSize.xy, crop, param.Rotation,
                    param.CENTER_AFTER_CROPPING, scale_o2i);

--- a/misc/shaders/crop_and_scale/crop_and_scale.slang
+++ b/misc/shaders/crop_and_scale/crop_and_scale.slang
@@ -1,5 +1,5 @@
 /*
-    Scaling library v1.0 by fishku
+    Cropping and scaling library v1.1 by fishku
     Copyright (C) 2023
     Public domain license (CC0)
 
@@ -15,10 +15,12 @@
     - Forcing of a certain aspect ratio
     - Forcing of either vert. or horiz. integer scaling, or both
     - Rotation support (0, 90, 180, 270 degrees).
+    - Overscaling
 
     Refactored from the version that used to be in the blur_fill shader.
 
     Changelog:
+    v1.1: Add overscaling option. Unify parameters.
     v1.0: Initial conversion from blur_fill release. Add rotation support.
 */
 
@@ -69,7 +71,7 @@ vec2 get_input_center(vec2 input_size, vec4 crop, uint rotation,
 // Scaling from unit output to pixel input space.
 vec2 get_scale_o2i(vec2 input_size, vec2 output_size, vec4 crop, uint rotation,
                    float center_after_cropping, float force_aspect_ratio,
-                   vec2 aspect, vec2 force_integer_scaling,
+                   vec2 aspect, vec2 force_integer_scaling, float overscale,
                    bool output_size_is_final_viewport_size) {
     crop = get_rotated_crop(crop, rotation);
     if (output_size_is_final_viewport_size) {
@@ -96,7 +98,9 @@ vec2 get_scale_o2i(vec2 input_size, vec2 output_size, vec4 crop, uint rotation,
         output_size.y / (input_size.y * aspect.y)) {
         // Scale will be limited by width. Calc x scale, then derive y scale
         // using aspect ratio.
-        scale_x = output_size.x / input_size.x;
+        scale_x = mix(output_size.x / input_size.x,
+                      output_size.y * aspect.x / (input_size.y * aspect.y),
+                      overscale);
         if (force_integer_scaling.x > 0.5 && scale_x > 1.0) {
             scale_x = floor(scale_x);
         }
@@ -106,7 +110,9 @@ vec2 get_scale_o2i(vec2 input_size, vec2 output_size, vec4 crop, uint rotation,
         }
     } else {
         // Scale will be limited by height.
-        scale_y = output_size.y / input_size.y;
+        scale_y = mix(output_size.y / input_size.y,
+                      output_size.x * aspect.y / (input_size.x * aspect.x),
+                      overscale);
         if (force_integer_scaling.y > 0.5 && scale_y > 1.0) {
             scale_y = floor(scale_y);
         }
@@ -131,11 +137,12 @@ vec2 o2i(vec2 x, vec2 input_size, vec4 crop, uint rotation,
 // Version that computes scale.
 vec2 o2i(vec2 x, vec2 input_size, vec2 output_size, vec4 crop, uint rotation,
          float center_after_cropping, float force_aspect_ratio, vec2 aspect,
-         vec2 force_integer_scaling, bool output_size_is_final_viewport_size) {
+         vec2 force_integer_scaling, float overscale,
+         bool output_size_is_final_viewport_size) {
     return o2i(x, input_size, crop, rotation, center_after_cropping,
                get_scale_o2i(input_size, output_size, crop, rotation,
                              center_after_cropping, force_aspect_ratio, aspect,
-                             force_integer_scaling,
+                             force_integer_scaling, overscale,
                              output_size_is_final_viewport_size));
 }
 
@@ -152,12 +159,13 @@ vec2 i2o(vec2 x, vec2 input_size, vec4 crop, uint rotation,
 // Version that computes scale.
 vec2 i2o(vec2 x, vec2 input_size, vec2 output_size, vec4 crop, uint rotation,
          float center_after_cropping, float force_aspect_ratio, vec2 aspect,
-         vec2 force_integer_scaling, bool output_size_is_final_viewport_size) {
+         vec2 force_integer_scaling, float overscale,
+         bool output_size_is_final_viewport_size) {
     return (x - get_input_center(input_size, crop, rotation,
                                  center_after_cropping)) /
                get_scale_o2i(input_size, output_size, crop, rotation,
                              center_after_cropping, force_aspect_ratio, aspect,
-                             force_integer_scaling,
+                             force_integer_scaling, overscale,
                              output_size_is_final_viewport_size) +
            0.49999;
 }

--- a/misc/shaders/crop_and_scale/parameters.slang
+++ b/misc/shaders/crop_and_scale/parameters.slang
@@ -1,0 +1,18 @@
+// clang-format off
+#pragma parameter SCALING_SETTINGS "= Scaling parameters =" 0.0 0.0 1.0 1.0
+#pragma parameter FORCE_ASPECT_RATIO "Force aspect ratio" 1.0 0.0 1.0 1.0
+#pragma parameter ASPECT_H "Horizontal aspect ratio before crop (0 = unchanged)" 0.0 0.0 256.0 1.0
+#pragma parameter ASPECT_V "Vertical aspect ratio before crop (0 = unchanged)" 0.0 0.0 256.0 1.0
+#pragma parameter FORCE_INTEGER_SCALING_H "Force integer scaling horizontally" 0.0 0.0 1.0 1.0
+#pragma parameter FORCE_INTEGER_SCALING_V "Force integer scaling vertically" 0.0 0.0 1.0 1.0
+
+#pragma parameter OVERSCALE "Overscale (0 = full image, 1 = full screen)" 0.0 0.0 1.0 0.01
+
+#pragma parameter CROPPING_SETTINGS "= Cropping parameters =" 0.0 0.0 1.0 1.0
+#pragma parameter OS_CROP_TOP "Overscan crop top" 0.0 0.0 1024.0 1.0
+#pragma parameter OS_CROP_BOTTOM "Overscan crop bottom" 0.0 0.0 1024.0 1.0
+#pragma parameter OS_CROP_LEFT "Overscan crop left" 0.0 0.0 1024.0 1.0
+#pragma parameter OS_CROP_RIGHT "Overscan crop right" 0.0 0.0 1024.0 1.0
+
+#pragma parameter CENTER_AFTER_CROPPING "Center cropped area" 1.0 0.0 1.0 1.0
+// clang-format on


### PR DESCRIPTION
- rename scaling to crop and scale
- organize uniforms in *_fill consistently
- refactor common crop and scale parameters into separate file
- add overscale option.