### PR TITLE
Update crt-geom-mini.slang

### DIFF
--- a/crt/shaders/crt-geom-mini.slang
+++ b/crt/shaders/crt-geom-mini.slang
@@ -25,8 +25,8 @@ layout(push_constant) uniform Push
 
 #pragma parameter CURV "CRT-Geom Curvature" 1.0 0.0 1.0 1.0
 #pragma parameter SCAN "CRT-Geom Scanline Weight" 0.25 0.2 0.6 0.05
-#pragma parameter MASK "CRT-Geom Dotmask Strength" 0.25 0.0 1.0 0.05
-#pragma parameter LUM "CRT-Geom Luminance" 0.1 0.0 0.5 0.01
+#pragma parameter MASK "CRT-Geom Dotmask Strength" 0.15 0.0 0.5 0.05
+#pragma parameter LUM "CRT-Geom Luminance" 0.05 0.0 0.5 0.01
 #pragma parameter INTERL "CRT-Geom Interlacing Simulation" 1.0 0.0 1.0 1.0
 #pragma parameter SAT "CRT-Geom Saturation" 1.1 0.0 2.0 0.01
 #pragma parameter LANC "Filter profile: Accurate/Fast" 0.0 0.0 1.0 1.0


### PR DESCRIPTION
better default settings, correct mask parameters