### PR TITLE
Bring handheld border GBC to parity with GBA

### DIFF
--- a/handheld/console-border/gbc.slangp
+++ b/handheld/console-border/gbc.slangp
@@ -1,14 +1,22 @@
-shaders = "2"
+shaders = "4"
 
-shader0 = "shader-files/lcd-cgwg/lcd-grid.slang"
-filter_linear0 = "false"
-scale_type0 = "viewport"
+shader0 = "../../motionblur/shaders/feedback.slang"
+filter_linear0 = false
 
-shader1 = "shader-files/gb-pass-5.slang"
-filter_linear1 = "true"
+shader1 = "../shaders/color/gbc-color.slang"
+filter_linear1 = false
 
-parameters = "video_scale"
+shader2 = "shader-files/lcd-cgwg/lcd-grid.slang"
+filter_linear2 = "false"
+scale_type2 = "viewport"
+
+shader3 = "shader-files/gb-pass-5.slang"
+filter_linear3 = "true"
+
+parameters = "video_scale;GRID_STRENGTH;mixfactor"
 video_scale = 4.0
+GRID_STRENGTH = "0.150000"
+mixfactor = "0.50"
 
 textures = "BORDER"
 BORDER = "resources/color-border-square-4x.png"


### PR DESCRIPTION
For some reason, the GBC preset does not include the feedback, nor, more importantly, the GBC color correction shaders.
I've updated the preset to bring it to parity to it's GBA counterpart.

I would also like to propose reducing the feedback (response time) amount slightly on both the GBC and GBA variants, as the current amount seems to be a bit distracting. The lcd-grid-v2 presets have lower amounts.
Or perhaps even replacing the feedback shader pass with the response-time one used in the lcd-grid-v2 presets? I don't really know the difference between the feedback and response-time shaders.