### PR TITLE
Do color correction before LCD grid and fix gamma

### DIFF
--- a/handheld/console-border/gba-lcd-grid-v2.slangp
+++ b/handheld/console-border/gba-lcd-grid-v2.slangp
@@ -1,10 +1,10 @@
 shaders = 4
 shader0 = ../../motionblur/shaders/response-time.slang
-shader1 = shader-files/lcd-cgwg/lcd-grid-v2.slang
-shader2 = ../shaders/color/gba-color.slang
+shader1 = ../shaders/color/gba-color.slang
+shader2 = shader-files/lcd-cgwg/lcd-grid-v2.slang
 shader3 = shader-files/gb-pass-5.slang
 
-scale_type1 = viewport
+scale_type2 = viewport
 
 filter_linear0 = false
 filter_linear1 = false
@@ -32,4 +32,3 @@ gamma = "2.2"
 blacklevel = "0"
 ambient = "0"
 BGR = "1"
-darken_screen = "0"

--- a/handheld/console-border/gbc-lcd-grid-v2.slangp
+++ b/handheld/console-border/gbc-lcd-grid-v2.slangp
@@ -1,10 +1,10 @@
 shaders = 4
 shader0 = ../../motionblur/shaders/response-time.slang
-shader1 = shader-files/lcd-cgwg/lcd-grid-v2.slang
-shader2 = ../shaders/color/gbc-color.slang
+shader1 = ../shaders/color/gbc-color.slang
+shader2 = shader-files/lcd-cgwg/lcd-grid-v2.slang
 shader3 = shader-files/gb-pass-5.slang
 
-scale_type1 = viewport
+scale_type2 = viewport
 
 filter_linear0 = false
 filter_linear1 = false
@@ -32,4 +32,3 @@ gamma = "2.2"
 blacklevel = "0"
 ambient = "0"
 BGR = "0"
-lighten_screen = "0"

--- a/handheld/lcd-grid-v2-gba-color.slangp
+++ b/handheld/lcd-grid-v2-gba-color.slangp
@@ -1,13 +1,13 @@
 shaders = "2"
 
-shader0 = "shaders/lcd-cgwg/lcd-grid-v2.slang"
+shader0 = "shaders/color/gba-color.slang"
 filter_linear0 = "false"
-scale_type0 = "viewport"
+scale_type0 = "source"
 scale0 = "1.0"
 
-shader1 = "shaders/color/gba-color.slang"
+shader1 = "shaders/lcd-cgwg/lcd-grid-v2.slang"
 filter_linear1 = "false"
-scale_type1 = "source"
+scale_type1 = "viewport"
 scale1 = "1.0"
 
 parameters = "RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR;darken_screen"
@@ -25,4 +25,3 @@ gamma = "2.2"
 blacklevel = "0"
 ambient = "0"
 BGR = "1"
-darken_screen = "0"

--- a/handheld/lcd-grid-v2-gbc-color.slangp
+++ b/handheld/lcd-grid-v2-gbc-color.slangp
@@ -1,13 +1,13 @@
 shaders = "2"
 
-shader0 = "shaders/lcd-cgwg/lcd-grid-v2.slang"
+shader0 = "shaders/color/gbc-color.slang"
 filter_linear0 = "false"
-scale_type0 = "viewport"
+scale_type0 = "source"
 scale0 = "1.0"
 
-shader1 = "shaders/color/gbc-color.slang"
+shader1 = "shaders/lcd-cgwg/lcd-grid-v2.slang"
 filter_linear1 = "false"
-scale_type1 = "source"
+scale_type1 = "viewport"
 scale1 = "1.0"
 
 parameters = "RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR;lighten_screen"
@@ -25,4 +25,3 @@ gamma = "2.2"
 blacklevel = "0"
 ambient = "0"
 BGR = "0"
-lighten_screen = "0"

--- a/handheld/shaders/color/gbc-color.slang
+++ b/handheld/shaders/color/gbc-color.slang
@@ -25,7 +25,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #pragma parameter mode "Color Profile (1=sRGB, 2=DCI, 3=Rec2020)" 1.0 1.0 3.0 1.0
 int color_mode = int(global.mode);
 
-#pragma parameter lighten_screen "Lighten Screen" 1.0 0.0 1.0 0.05
+#pragma parameter lighten_screen "Lighten Screen" 0.5 0.0 1.0 0.05
 
 #define target_gamma 2.2
 #define display_gamma 2.2


### PR DESCRIPTION
This is a follow-up to https://github.com/libretro/slang-shaders/pull/505

I don't tend to agree with doing color correction after the LCD shader.
I have read the justification Pokefan531 posted a few months ago, but after testing both options, it still doesn't make sense to me.

Look how different the subpixels look when using the color correction after the LCD.

Correction after LCD grid:
![Pokemon - Gold Version (USA, Europe) (SGB Enhanced) (GB Compatible)-240117-225519](https://github.com/libretro/slang-shaders/assets/11202422/fea72aca-3d31-4564-837c-976c3da36a59)

Correction before LCD grid:
![Pokemon - Gold Version (USA, Europe) (SGB Enhanced) (GB Compatible)-240117-225605](https://github.com/libretro/slang-shaders/assets/11202422/7c407aff-b050-4455-868a-e4e6a77dc913)

Doing correction after the LCD grid decreases the subpixel color saturation and reduces the LCD grid effect. I don’t feel like this is the intended behavior of color and gamma correction.

Also, he suggested using the LCD grid shader gamma controls to control the gamma, but that has weird effects. For example, a full white screen should look exactly the same regardless of gamma value, as gamma does not affect full white. But look at the following test:

![image](https://github.com/libretro/slang-shaders/assets/11202422/05c84c38-95d6-4d9f-afcc-42a3fcb89e84)

These 2 pictures should look the exact same, as gamma doesn’t affect white, but they look very different here.

This also happens if we control the gamma with the `lighten_screen` and `darken_screen` parameters. The subpixels are being affected if we do the color correction after the LCD grid, even on full white.

Additionally, I've set the GBC `lighten_screen` to a more moderate value of 0.5, as it's closer to a real GBC screen. Pokefan531 is of the same opinion on that.