### PR TITLE
Game Boy Color / Light and Dark Mode Game Boy / Invert Colors

### DIFF
--- a/handheld/gameboy-color.slangp
+++ b/handheld/gameboy-color.slangp
@@ -1,0 +1,39 @@
+shaders = 5
+
+shader0 = shaders/gameboy/shader-files/gb-pass0.slang
+filter_linear0 = false
+scale_type0 = viewport
+scale0 = 1.0
+alias0 = "PASS0"
+color_toggle = "1.000000"
+
+shader1 = shaders/gameboy/shader-files/gb-pass1.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 1.0
+alias1 = "PASS1"
+
+shader2 = shaders/gameboy/shader-files/gb-pass2.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+alias2 = "PASS2"
+
+shader3 = shaders/gameboy/shader-files/gb-pass3.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+alias3 = "PASS3"
+
+shader4 = shaders/gameboy/shader-files/gb-pass4.slang
+filter_linear4 = false
+scale_type4 = source
+scale4 = 1.0
+alias4 = "PASS4"
+
+
+textures = COLOR_PALETTE;BACKGROUND
+COLOR_PALETTE = shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true

--- a/handheld/gameboy-dark-mode.slangp
+++ b/handheld/gameboy-dark-mode.slangp
@@ -1,0 +1,41 @@
+shaders = 6
+
+shader0 = shaders/gameboy/shader-files/gb-pass0.slang
+filter_linear0 = false
+scale_type0 = viewport
+scale0 = 1.0
+alias0 = "PASS0"
+
+shader1 = shaders/gameboy/shader-files/gb-pass1.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 1.0
+alias1 = "PASS1"
+
+shader2 = shaders/gameboy/shader-files/gb-pass2.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+alias2 = "PASS2"
+
+shader3 = shaders/gameboy/shader-files/gb-pass3.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+alias3 = "PASS3"
+
+shader4 = shaders/gameboy/shader-files/gb-pass4.slang
+filter_linear4 = false
+scale_type4 = source
+scale4 = 1.0
+alias4 = "PASS4"
+
+shader5 = ../misc/shaders/image-adjustment.slang
+ia_invert = "1.000000"
+
+
+textures = COLOR_PALETTE;BACKGROUND
+COLOR_PALETTE = shaders/gameboy/resources/sample-palettes/b-w-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true

--- a/handheld/gameboy-light-mode.slangp
+++ b/handheld/gameboy-light-mode.slangp
@@ -1,0 +1,38 @@
+shaders = 5
+
+shader0 = shaders/gameboy/shader-files/gb-pass0.slang
+filter_linear0 = false
+scale_type0 = viewport
+scale0 = 1.0
+alias0 = "PASS0"
+
+shader1 = shaders/gameboy/shader-files/gb-pass1.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 1.0
+alias1 = "PASS1"
+
+shader2 = shaders/gameboy/shader-files/gb-pass2.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+alias2 = "PASS2"
+
+shader3 = shaders/gameboy/shader-files/gb-pass3.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+alias3 = "PASS3"
+
+shader4 = shaders/gameboy/shader-files/gb-pass4.slang
+filter_linear4 = false
+scale_type4 = source
+scale4 = 1.0
+alias4 = "PASS4"
+
+
+textures = COLOR_PALETTE;BACKGROUND
+COLOR_PALETTE = shaders/gameboy/resources/sample-palettes/b-w-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true

--- a/handheld/shaders/gameboy/shader-files/gb-pass0.slang
+++ b/handheld/shaders/gameboy/shader-files/gb-pass0.slang
@@ -10,6 +10,7 @@ layout(push_constant) uniform Push
 	float grey_balance;
 	float response_time;
 	float video_scale;
+    float color_toggle;
 } registers;
 
 layout(std140, set = 0, binding = 0) uniform UBO
@@ -20,6 +21,8 @@ layout(std140, set = 0, binding = 0) uniform UBO
 ////////////////////////////////////////////////////////////////////////////////
 // Config                                                                     //
 ////////////////////////////////////////////////////////////////////////////////
+
+#pragma parameter color_toggle "Color Toggle" 0.0 0.0 1.0 1.0 // Toggle between color (1.0) and greyscale (0.0)
 
 // The alpha value of dots in their "off" state
 // Does not affect the border region of the screen - [0, 1]
@@ -40,6 +43,8 @@ layout(std140, set = 0, binding = 0) uniform UBO
 // Gameboy Classic Shader v0.2.2                                         //
 //                                                                       //
 // Copyright (C) 2013 Harlequin : unknown92835@gmail.com                 //
+//                                                                       //
+// Modified 2/6/24 to support color output by mattakins.                 //
 //                                                                       //
 // This program is free software: you can redistribute it and/or modify  //
 // it under the terms of the GNU General Public License as published by  //
@@ -116,6 +121,9 @@ layout(set = 0, binding = 10) uniform sampler2D COLOR_PALETTE;
 ////////////////////////////////////////////////////////////////////////////////
 
 #define foreground_color texture(COLOR_PALETTE, vec2(0.75, 0.5)).rgb                 //hardcoded to look up the foreground color from the right half of the palette image
+
+vec3 foreground_source = texture(Source, vTexCoord).rgb; // samples color from source for color mode
+
 //#define rgb_to_alpha(rgb) ( ((rgb.r + rgb.g + rgb.b) / 3.0) + (is_on_dot * vec2(registers.baseline_alpha), 1.0) )       //averages rgb values (allows it to work with color games), modified for contrast and base alpha
 
 
@@ -153,7 +161,13 @@ void main()
     // Apply foreground color and assign alpha value
     // Apply the foreground color to all texels -
     // the color will be modified by alpha later - and assign alpha based on rgb input
-    vec4 out_color = vec4(foreground_color, rgb_to_alpha);  
+    
+    vec4 out_color;
+
+    if (registers.color_toggle == 0.0)
+        out_color = vec4(foreground_color, rgb_to_alpha);
+    else
+        out_color = vec4(foreground_source, rgb_to_alpha);
 
     // Overlay the matrix
     // If the fragment is not on a dot, set its alpha value to 0

--- a/misc/shaders/image-adjustment.slang
+++ b/misc/shaders/image-adjustment.slang
@@ -13,6 +13,7 @@ layout(push_constant) uniform Push
 	float ia_luminance;
 	float ia_black_level;
 	float ia_bright_boost;
+	float ia_invert;
 	float ia_R;
 	float ia_G;
 	float ia_B;
@@ -43,6 +44,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #pragma parameter ia_luminance "Luminance" 1.0 0.0 2.0 0.1
 #pragma parameter ia_black_level "Black Level" 0.00 -0.30 0.30 0.01
 #pragma parameter ia_bright_boost "Brightness Boost" 0.0 -1.0 1.0 0.05
+#pragma parameter ia_invert "Invert Colors" 0.0 0.0 1.0 1.0
 #pragma parameter ia_R "Red Channel" 1.0 0.0 2.0 0.05
 #pragma parameter ia_G "Green Channel" 1.0 0.0 2.0 0.05
 #pragma parameter ia_B "Blue Channel" 1.0 0.0 2.0 0.05
@@ -122,6 +124,11 @@ void main()
    conColor = pow(conColor, 1.0 / vec3(gamma)); // Apply gamma correction
    conColor *= vec3(registers.ia_R, registers.ia_G, registers.ia_B);
    
+//invert colors
+   if (registers.ia_invert > 0.5) {
+       conColor = 1.0 - conColor; // Invert colors
+   }
+
 //overscan mask
 if (vTexCoord.y > registers.ia_TOPMASK && vTexCoord.y < (1.0 - registers.ia_BOTMASK))
    conColor = conColor;


### PR DESCRIPTION
@hizzlekizzle - Updated based on your feedback.
- Added 'invert colors' as a parameter to 'image-adjustment'.
- I kept gameboy-light-mode and gameboy-dark-mode as separate presets. I think this makes more sense to the end user. They all reference the same shader files but with different background and palette parameters.
- Game Boy Color preset now references the original handheld/gameboy shader files. I modified gb-pass0 to support color based on a toggle.