### PR TITLE
crt-geom-mini update from glsl, crt-pocket fix clamp error

### DIFF
--- a/crt/shaders/crt-geom-mini.slang
+++ b/crt/shaders/crt-geom-mini.slang
@@ -24,11 +24,11 @@ layout(push_constant) uniform Push
 // Parameter lines go here:
 
 #pragma parameter CURV "CRT-Geom Curvature" 1.0 0.0 1.0 1.0
-#pragma parameter SCAN "CRT-Geom Scanline Weight" 0.25 0.2 0.6 0.05
+#pragma parameter SCAN "CRT-Geom Scanline Weight" 0.3 0.2 0.6 0.05
 #pragma parameter MASK "CRT-Geom Dotmask Strength" 0.15 0.0 0.5 0.05
-#pragma parameter LUM "CRT-Geom Luminance" 0.05 0.0 0.5 0.01
+#pragma parameter LUM "CRT-Geom Luminance" 0.0 0.0 0.5 0.01
 #pragma parameter INTERL "CRT-Geom Interlacing Simulation" 1.0 0.0 1.0 1.0
-#pragma parameter SAT "CRT-Geom Saturation" 1.1 0.0 2.0 0.01
+#pragma parameter SAT "CRT-Geom Saturation" 1.0 0.0 2.0 0.01
 #pragma parameter LANC "Filter profile: Accurate/Fast" 0.0 0.0 1.0 1.0
 
 #define PI 3.1415926535897932384626433
@@ -80,18 +80,30 @@ layout(set = 0, binding = 1) uniform sampler2D Source;
 
 float scan(float pos, vec3 color)
     {
-    float wid = SCAN + 0.1 * max(max(color.r,color.g),color.b);
+    float wid = SCAN + 0.15 *dot(vec3(0.15),color);
     float weight = pos / wid;
-    return  LUM + (0.1 + SCAN) * exp(-weight * weight ) / wid;
+    return  (LUM + (0.2 + SCAN)) * exp(-weight*weight ) / wid*1.25;
     }
 
-vec2 Warp(vec2 pos)
+vec2 Warp(vec2 coord)
 {
-    pos = warp;
-    pos *= vec2(1.0+pos.y*pos.y*0.031, 1.0+pos.x*pos.x*0.05);
-    pos = pos*0.5+0.5;
-    return pos;
+        vec2 CURVATURE_DISTORTION = vec2(0.13, 0.25);
+        // Barrel distortion shrinks the display area a bit, this will allow us to counteract that.
+        vec2 barrelScale = vec2(0.985,0.945);
+        coord -= vec2(0.5);
+        float rsq = coord.x*coord.x + coord.y*coord.y;
+        coord += coord * (CURVATURE_DISTORTION * rsq);
+        coord *= barrelScale;
+        if (abs(coord.x) >= 0.5 || abs(coord.y) >= 0.5)
+                coord = vec2(-1.0);             // If out of bounds, return an invalid value.
+        else
+        {
+                coord += vec2(0.5);
+        }
+
+        return coord;
 }
+
 
 void main()
 {
@@ -104,25 +116,30 @@ void main()
 
     if (CURV == 1.0) pos /= scale;
 
+
 // Lanczos 2
     // Source position in fractions of a texel
     vec2 src_pos = pos*SourceSize.xy;
+    vec2 near = floor(src_pos)+0.5;
+    vec2 i = src_pos-near;
+    vec2 c = (near + 4.0*i*i*i)*SourceSize.zw;
+ 
     // Source bottom left texel centre
     vec2 src_centre = floor(src_pos - 0.5) + 0.5;
     // f is position. f.x runs left to right, y bottom to top, z right to left, w top to bottom
     vec4 f; 
     f.xy = src_pos - src_centre;
     f.zw = 1.0 - f.xy;
+
     // Calculate weights in x and y in parallel.
     // These polynomials are piecewise approximation of Lanczos kernel
     // Calculator here: https://gist.github.com/going-digital/752271db735a07da7617079482394543
- vec4 l2_w0_o3, l2_w1_o3;
+    vec4 l2_w0_o3, l2_w1_o3;
     if (LANC == 0.0)
-     {l2_w0_o3 = (((1.5672) * f - 2.6445) * f + 0.0837) * f + 0.9976;
-      l2_w1_o3 = (((-0.7389) * f + 1.3652) * f - 0.6295) * f - 0.0004;}
-    else  {l2_w0_o3 = (-1.1828) * f + 1.1298;
-           l2_w1_o3 = (0.0858) * f - 0.0792;}
-
+     {l2_w0_o3 = (( 1.567*f - 2.645)*f + 0.084)*f + 0.998;
+      l2_w1_o3 = ((-0.739*f + 1.365)*f - 0.629)*f - 0.0004;}
+    else  {l2_w0_o3 = (-1.183) * f + 1.130;
+           l2_w1_o3 = ( 0.086) * f - 0.079;}
 
     vec4 w1_2  = l2_w0_o3;
     vec2 w12   = w1_2.xy + w1_2.zw;
@@ -138,14 +155,13 @@ void main()
     wedge /= sum;
 
     vec3 res = vec3(
-        texture(Source, vec2(tc12.x, tc0.y)).rgb * wedge.y +
-        texture(Source, vec2(tc0.x, tc12.y)).rgb * wedge.x +
-        texture(Source, tc12.xy).rgb * (w12.x * w12.y) +
-        texture(Source, vec2(tc3.x, tc12.y)).rgb * wedge.z +
-        texture(Source, vec2(tc12.x, tc3.y)).rgb * wedge.w
+        texture(Source, vec2(tc12.x, c.y)).rgb * wedge.y +
+        texture(Source, vec2(tc0.x, c.y)).rgb * wedge.x +
+        texture(Source, vec2(tc12.x,c.y)).rgb * (w12.x * w12.y) +
+        texture(Source, vec2(tc3.x, c.y)).rgb * wedge.z +
+        texture(Source, vec2(tc12.x, c.y)).rgb * wedge.w
     );
-
-
+    res =clamp(res,0.0,1.0);
     float fp = fract(src_pos.y-0.5);
     if (OriginalSize.y > 400.0) fp = fract(src_pos.y/2.0-0.5);
 
@@ -157,11 +173,9 @@ void main()
     float scn  = scan(fp,res) + scan(1.0-fp,res);
     float msk  = MASK*sin(fragpos)+1.0-MASK;
     res *= sqrt(scn*msk);
-
     float l = dot(vec3(0.29, 0.6, 0.11), res);
     res  = mix(vec3(l), res, SAT);
-
-if (corn.y <= corn.x && CURV == 1.0 || corn.x < 0.0001 && CURV == 1.0 ) res = vec3(0.0);
+    if (corn.y <= corn.x && CURV == 1.0 || corn.x < 0.0001 && CURV == 1.0 ) res = vec3(0.0);
 
     FragColor = vec4(res,1.0);
 }

--- a/crt/shaders/crt-pocket.slang
+++ b/crt/shaders/crt-pocket.slang
@@ -1,4 +1,5 @@
 #version 450
+
 /*
 
    This program is free software; you can redistribute it and/or
@@ -402,7 +403,11 @@ if (OriginalSize.y > 400.0 && interlace == 0.0 && progress == 1.0)
 
     
     vec3 res = Lanczos3(pos,InvResolution);
-    if (ntsc == 1.0) res = NTSCtoSRGB(res);
+    if (ntsc == 1.0) {
+    
+        res = NTSCtoSRGB(res);
+        res = clamp(res,0.0,1.0);
+    }
     res *= ColorTemp(TEMP);
 
     float lumscan = max(max(res.r,res.g),res.b);


### PR DESCRIPTION
not tested crt-pocket (cannot reproduce the error) but should work. crt-geom-mini now almost matches crt-geom and 3x faster.