### PR TITLE
Fix a 7-year old bug in crt-royale-bloom-approx.h

### DIFF
--- a/crt/shaders/crt-royale/src/crt-royale-bloom-approx.h
+++ b/crt/shaders/crt-royale/src/crt-royale-bloom-approx.h
@@ -363,5 +363,5 @@ void main()
         color = float3(color_r.r, color_g.g, color_b.b);
     }
     //  Encode and output the blurred image:
-		FragColor = encode_output(float4(tex2D_linearize(ORIG_LINEARIZED, tex_uv)));
+    FragColor = encode_output(float4(color, 1.0));
 }


### PR DESCRIPTION
- It wasn't outputting the correct shader calculations and just spitting input colors;
- This bug only causes a slightly sharpening of final picture, so I understand that it passed unnoticed through porting.