### PR TITLE
Update crt-royale-fast and its presets

### DIFF
--- a/crt/shaders/crt-royale/src-fast/bind-shader-params.h
+++ b/crt/shaders/crt-royale/src-fast/bind-shader-params.h
@@ -79,13 +79,13 @@ float gba_gamma = 3.5; //  Irrelevant but necessary to define.
 #pragma parameter bloom_excess "Bloom - Excess" 0.0 0.0 1.0 0.005
 #pragma parameter beam_min_sigma "Beam - Min Sigma" 0.055 0.005 1.0 0.005
 #define beam_min_sigma global.beam_min_sigma
-#pragma parameter beam_max_sigma "Beam - Max Sigma" 0.255 0.005 1.0 0.005
+#pragma parameter beam_max_sigma "Beam - Max Sigma" 0.2 0.005 1.0 0.005
 #define beam_max_sigma global.beam_max_sigma
 #pragma parameter beam_spot_power "Beam - Spot Power" 0.38 0.01 16.0 0.01
 #define beam_spot_power global.beam_spot_power
 #pragma parameter beam_min_shape "Beam - Min Shape" 2.0 2.0 32.0 0.1
 #define beam_min_shape global.beam_min_shape
-#pragma parameter beam_max_shape "Beam - Max Shape" 4.0 2.0 32.0 0.1
+#pragma parameter beam_max_shape "Beam - Max Shape" 2.0 2.0 32.0 0.1
 #define beam_max_shape global.beam_max_shape
 #pragma parameter beam_shape_power "Beam - Shape Power" 0.25 0.01 16.0 0.01
 #define beam_shape_power global.beam_shape_power

--- a/presets/crt-royale-ntsc-composite-fast.slangp
+++ b/presets/crt-royale-ntsc-composite-fast.slangp
@@ -117,5 +117,6 @@ scale11 = "1.0"
 srgb_framebuffer11 = "true"
 wrap_mode11 = "clamp_to_edge"
 
-ntsc_cscale = "2.250000"
+ntsc_cscale = "4.000000"
+ntsc_cscale1 = "2.250000"
 beam_horiz_filter = "3.000000"

--- a/presets/crt-royale-pvm-blend.slangp
+++ b/presets/crt-royale-pvm-blend.slangp
@@ -1,4 +1,5 @@
 #reference "../crt/crt-royale-fast.slangp"
-bloom_underestimate_levels = "0.800000"
-beam_horiz_filter = "2.000000"
 mask_triad_size_desired = "1.000000"
+beam_max_sigma = "0.200000"
+beam_max_shape = "2.000000"
+beam_horiz_filter = "2.000000"

--- a/presets/crt-royale-pvm-ntsc-composite.slangp
+++ b/presets/crt-royale-pvm-ntsc-composite.slangp
@@ -1,3 +1,2 @@
 #reference "crt-royale-ntsc-composite-fast.slangp"
-bloom_underestimate_levels = "0.800000"
 mask_triad_size_desired = "1.000000"

--- a/presets/crt-royale-pvm-shmup.slangp
+++ b/presets/crt-royale-pvm-shmup.slangp
@@ -1,5 +1,4 @@
 #reference "../crt/crt-royale-fast.slangp"
-bloom_underestimate_levels = "0.800000"
 mask_triad_size_desired = "1.000000"
 geom_curvature = "1.000000"
 geom_R = "6.000000"

--- a/presets/crt-royale-pvm.slangp
+++ b/presets/crt-royale-pvm.slangp
@@ -1,3 +1,4 @@
 #reference "../crt/crt-royale-fast.slangp"
-bloom_underestimate_levels = "0.800000"
 mask_triad_size_desired = "1.000000"
+beam_max_sigma = "0.200000"
+beam_max_shape = "2.000000"


### PR DESCRIPTION
- Better uneven scanlines at non-integer scalings.