### PR TITLE
Update crt-geom.slang

### DIFF
--- a/crt/shaders/crt-geom.slang
+++ b/crt/shaders/crt-geom.slang
@@ -353,15 +353,7 @@ float corner(vec2 coord)
       return clamp((cdist.y - dist)*registers.cornersmooth, 0.0, 1.0);
 }
 
-// A collection of CRT mask effects that work with LCD subpixel structures for
-// small details
-//
-// author: hunterk
-// license: public domain
-//
-// Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
-// those have their filenames included for easy identification
-
+// Masks adapted from cgwg's crt-geom-deluxe LUTs.
 vec3 mask_weights_alpha(vec2 coord, float mask_intensity, int phosphor_layout, out float alpha){
    vec3 weights = vec3(1.,1.,1.);
    float on = 1.;

--- a/crt/shaders/crt-geom.slang
+++ b/crt/shaders/crt-geom.slang
@@ -13,7 +13,9 @@ layout(push_constant) uniform Push
 	float y_tilt;
 	float overscan_x;
 	float overscan_y;
+	float mask_type;
 	float DOTMASK;
+	float DOTMASK_brightboost;
 	float SHARPER;
 	float scanline_weight;
 	float CURVATURE;
@@ -44,7 +46,9 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #pragma parameter y_tilt "CRTGeom Vertical Tilt" 0.0 -0.5 0.5 0.05
 #pragma parameter overscan_x "CRTGeom Horiz. Overscan %" 100.0 -125.0 125.0 0.5
 #pragma parameter overscan_y "CRTGeom Vert. Overscan %" 100.0 -125.0 125.0 0.5
-#pragma parameter DOTMASK "CRTGeom Dot Mask Strength" 0.3 0.0 1.0 0.05
+#pragma parameter mask_type "CRTGeom Mask Pattern" 1.0 1.0 20.0 1.0
+#pragma parameter DOTMASK "CRTGeom Mask strength" 0.3 0.0 1.0 0.05
+#pragma parameter DOTMASK_brightboost "CRTGeom Mask brightness boost" 0.0 0.0 1.0 0.05
 #pragma parameter SHARPER "CRTGeom Sharpness" 1.0 1.0 3.0 1.0
 #pragma parameter scanline_weight "CRTGeom Scanline Weight" 0.3 0.1 0.5 0.05
 #pragma parameter vertical_scanlines "CRTGeom Vertical Scanlines" 0.0 0.0 1.0 1.0
@@ -99,6 +103,12 @@ vec4 SourceSize = vec4(width.x, height.x, width.y, height.y);
 #else
 #       define TEX2D(c) texture(Source, (c))
 #endif
+
+#define u_quad_dims global.OutputSize.xy
+#define u_tex_size1 vec2(global.OutputSize.xy * global.SourceSize.zw)
+
+#define DOTMASK registers.DOTMASK
+#define DOTMASK_brightboost registers.DOTMASK_brightboost
 
 // aspect ratio
 vec2 aspect     = vec2(registers.invert_aspect > 0.5 ? (0.75, 1.0) : (1.0, 0.75));
@@ -343,6 +353,376 @@ float corner(vec2 coord)
       return clamp((cdist.y - dist)*registers.cornersmooth, 0.0, 1.0);
 }
 
+// A collection of CRT mask effects that work with LCD subpixel structures for
+// small details
+//
+// author: hunterk
+// license: public domain
+//
+// Many of these mask arrays are adapted from cgwg's crt-geom-deluxe LUTs, and
+// those have their filenames included for easy identification
+
+vec3 mask_weights_alpha(vec2 coord, float mask_intensity, int phosphor_layout, out float alpha){
+   vec3 weights = vec3(1.,1.,1.);
+   float on = 1.;
+   float off = 1.-mask_intensity;
+   vec3 red     = vec3(on,  off, off);// 1
+   vec3 green   = vec3(off, on,  off);// 1
+   vec3 blue    = vec3(off, off, on );// 1
+   vec3 magenta = vec3(on,  off, on );// 2
+   vec3 yellow  = vec3(on,  on,  off);// 2
+   vec3 cyan    = vec3(off, on,  on );// 2
+   vec3 black   = vec3(off, off, off);// 0
+   vec3 white   = vec3(on,  on,  on );// 3
+   int w, z = 0;
+   alpha = 1.;
+   
+   // This pattern is used by a few layouts, so we'll define it here
+   vec3 aperture_weights = mix(magenta, green, floor(mod(coord.x, 2.0)));
+   
+   if(phosphor_layout == 0) return weights;
+
+   else if(phosphor_layout == 1){
+      // classic aperture for RGB panels; good for 1080p, too small for 4K+
+      // aka aperture_1_2_bgr
+      weights.rgb  = aperture_weights;
+	  alpha = 3./6.;
+      return weights;
+   }
+
+   else if(phosphor_layout == 2){
+      // 2x2 shadow mask for RGB panels; good for 1080p, too small for 4K+
+      // aka delta_1_2x1_bgr
+      vec3 inverse_aperture = mix(green, magenta, floor(mod(coord.x, 2.0)));
+      weights               = mix(aperture_weights, inverse_aperture, floor(mod(coord.y, 2.0)));
+      alpha = 6./12.;
+      return weights;
+   }
+
+   else if(phosphor_layout == 3){
+      // slot mask for RGB panels; looks okay at 1080p, looks better at 4K
+      vec3 slotmask[3][4] = {
+         {magenta, green, black,   black},
+         {magenta, green, magenta, green},
+         {black,   black, magenta, green}
+      };
+      
+      // find the vertical index
+      w = int(floor(mod(coord.y, 3.0)));
+
+      // find the horizontal index
+      z = int(floor(mod(coord.x, 4.0)));
+
+      // use the indexes to find which color to apply to the current pixel
+      weights = slotmask[w][z];
+      alpha = 12./36.;
+      return weights;
+   }
+
+   else if(phosphor_layout == 4){
+      // classic aperture for RBG panels; good for 1080p, too small for 4K+
+      weights  = mix(yellow, blue, floor(mod(coord.x, 2.0)));
+      alpha = 3./6.;
+      return weights;
+   }
+
+   else if(phosphor_layout == 5){
+      // 2x2 shadow mask for RBG panels; good for 1080p, too small for 4K+
+      vec3 inverse_aperture = mix(blue, yellow, floor(mod(coord.x, 2.0)));
+      weights               = mix(mix(yellow, blue, floor(mod(coord.x, 2.0))), inverse_aperture, floor(mod(coord.y, 2.0)));
+      alpha = 6./12.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 6){
+      // aperture_1_4_rgb; good for simulating lower 
+      vec3 ap4[4] = vec3[](red, green, blue, black);
+      
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = ap4[z];
+      alpha = 3./12.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 7){
+      // aperture_2_5_bgr
+      vec3 ap3[5] = vec3[](red, magenta, blue, green, green);
+      
+      z = int(floor(mod(coord.x, 5.0)));
+      
+      weights = ap3[z];
+      alpha = 6./15.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 8){
+      // aperture_3_6_rgb
+      
+      vec3 big_ap[7] = vec3[](red, red, yellow, green, cyan, blue, blue);
+      
+      w = int(floor(mod(coord.x, 7.)));
+      
+      weights = big_ap[w];
+      alpha = 8./18.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 9){
+      // reduced TVL aperture for RGB panels
+      // aperture_2_4_rgb
+      
+      vec3 big_ap_rgb[4] = vec3[](red, yellow, cyan, blue);
+      
+      w = int(floor(mod(coord.x, 4.)));
+      
+      weights = big_ap_rgb[w];
+      alpha = 6./12.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 10){
+      // reduced TVL aperture for RBG panels
+      
+      vec3 big_ap_rbg[4] = vec3[](red, magenta, cyan, green);
+      
+      w = int(floor(mod(coord.x, 4.)));
+      
+      weights = big_ap_rbg[w];
+      alpha = 6./12.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 11){
+      // delta_1_4x1_rgb; dunno why this is called 4x1 when it's obviously 4x2 /shrug
+      vec3 delta1[2][4] = {
+         {red,  green, blue, black},
+         {blue, black, red,  green}
+      };
+      
+      w = int(floor(mod(coord.y, 2.0)));
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = delta1[w][z];
+      alpha = 6./24.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 12){
+      // delta_2_4x1_rgb
+      vec3 delta[2][4] = {
+         {red, yellow, cyan, blue},
+         {cyan, blue, red, yellow}
+      };
+      
+      w = int(floor(mod(coord.y, 2.0)));
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = delta[w][z];
+      alpha = 12./24.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 13){
+      // delta_2_4x2_rgb
+      vec3 delta[4][4] = {
+         {red,  yellow, cyan, blue},
+         {red,  yellow, cyan, blue},
+         {cyan, blue,   red,  yellow},
+         {cyan, blue,   red,  yellow}
+      };
+      
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = delta[w][z];
+      alpha = 24./48.;
+      return weights;
+   }
+
+   else if(phosphor_layout == 14){
+      // slot mask for RGB panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+      vec3 slotmask[3][6] = {
+         {magenta, green, black, black,   black, black},
+         {magenta, green, black, magenta, green, black},
+         {black,   black, black, magenta, green, black}
+      };
+      
+      w = int(floor(mod(coord.y, 3.0)));
+
+      z = int(floor(mod(coord.x, 6.0)));
+
+      weights = slotmask[w][z];
+      alpha = 12./54.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 15){
+      // slot_2_4x4_rgb
+      vec3 slot2[4][8] = {
+         {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+         {red,   yellow, cyan,  blue,  black, black,  black, black},
+         {red,   yellow, cyan,  blue,  red,   yellow, cyan,  blue },
+         {black, black,  black, black, red,   yellow, cyan,  blue }
+      };
+   
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 8.0)));
+      
+      weights = slot2[w][z];
+      alpha = 36./96.;
+      return weights;
+   }
+
+   else if(phosphor_layout == 16){
+      // slot mask for RBG panels; too low-pitch for 1080p, looks okay at 4K, but wants 8K+
+      vec3 slotmask[3][4] = {
+         {yellow, blue,  black,  black},
+         {yellow, blue,  yellow, blue},
+         {black,  black, yellow, blue}
+      };
+      
+      w = int(floor(mod(coord.y, 3.0)));
+
+      z = int(floor(mod(coord.x, 4.0)));
+
+      weights = slotmask[w][z];
+      alpha = 14./36.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 17){
+      // slot_2_5x4_bgr
+      vec3 slot2[4][10] = {
+         {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+         {black, blue,    blue,  green, green, red,   red,     black, black, black},
+         {red,   magenta, blue,  green, green, red,   magenta, blue,  green, green},
+         {red,   red,     black, black, black, black, blue,    blue,  green, green}
+      };
+   
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 10.0)));
+      
+      weights = slot2[w][z];
+      alpha = 36./120.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 18){
+      // same as above but for RBG panels
+      vec3 slot2[4][10] = {
+         {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+         {black, green,  green, blue,  blue,  red,   red,    black, black, black},
+         {red,   yellow, green, blue,  blue,  red,   yellow, green, blue,  blue },
+         {red,   red,    black, black, black, black, green,  green, blue,  blue }
+      };
+   
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 10.0)));
+      
+      weights = slot2[w][z];
+      alpha = 36./120.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 19){
+      // slot_3_7x6_rgb
+      vec3 slot[6][14] = {
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  black, black, black,  black,  black, black, black},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {red,   red,   yellow, green, cyan,  blue,  blue,  red,   red,   yellow, green,  cyan,  blue,  blue},
+         {black, black, black,  black, black, black, black, black, red,   red,    yellow, green, cyan,  blue}
+      };
+      
+      w = int(floor(mod(coord.y, 6.0)));
+      z = int(floor(mod(coord.x, 14.0)));
+      
+      weights = slot[w][z];
+      alpha = 89./252.; // 49+(2*20)
+      return weights;
+   }
+
+   else if(phosphor_layout == 20){
+      // TATE slot mask for RGB layouts; this is not realistic obviously, but it looks nice and avoids chromatic aberration
+      vec3 tatemask[4][4] = {
+         {green, magenta, green, magenta},
+         {black, blue,    green, red},
+         {green, magenta, green, magenta},
+         {green, red,     black, blue}
+      };
+      
+      w = int(floor(mod(coord.y, 4.0)));
+
+      z = int(floor(mod(coord.x, 4.0)));
+
+      weights = tatemask[w][z];
+      alpha = 18./48.;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 21){
+      // based on MajorPainInTheCactus' HDR slot mask
+      vec3 slot[4][8] = {
+         {red,   green, blue,  black, red,   green, blue,  black},
+         {red,   green, blue,  black, black, black, black, black},
+         {red,   green, blue,  black, red,   green, blue,  black},
+         {black, black, black, black, red,   green, blue,  black}
+      };
+      
+      w = int(floor(mod(coord.y, 4.0)));
+      z = int(floor(mod(coord.x, 8.0)));
+      
+      weights = slot[w][z];
+      alpha = 21./96.;
+      return weights;
+   }
+	
+   else if(phosphor_layout == 22){
+      // black and white aperture; good for weird subpixel layouts and low brightness; good for 1080p and lower
+      vec3 bw3[3] = vec3[](black, white, white);
+      
+      z = int(floor(mod(coord.x, 3.0)));
+      
+      weights = bw3[z];
+      alpha = 2./3.;
+      return weights;
+   }
+
+   else if(phosphor_layout == 23){
+      // black and white aperture; good for weird subpixel layouts and low brightness; good for 4k 
+      vec3 bw4[4] = vec3[](black, black, white, white);
+      
+      z = int(floor(mod(coord.x, 4.0)));
+      
+      weights = bw4[z];
+      alpha = 0.5;
+      return weights;
+   }
+   
+   else if(phosphor_layout == 24){
+      // shadowmask courtesy of Louis. Suitable for lower TVL on high-res 4K+ screens
+      vec3 shadow[6][10] = {
+         {green, cyan, blue, blue, blue, red, red, red, yellow, green},
+         {green, cyan, blue, blue, blue, red, red, red, yellow, green},
+         {green, cyan, blue, blue, blue, red, red, red, yellow, green},
+         {red, red, red, yellow, green, green, cyan, blue, blue, blue},
+         {red, red, red, yellow, green, green, cyan, blue, blue, blue},
+         {red, red, red, yellow, green, green, cyan, blue, blue, blue},
+      };
+      
+      w = int(floor(mod(coord.y, 6.0)));
+      z = int(floor(mod(coord.x, 10.0)));
+      
+      weights = shadow[w][z];
+      alpha = 72./180.;
+      return weights;
+   }
+
+   else return weights;
+}
+
 void main()
 {
     // Here's a helpful diagram to keep in mind while trying to
@@ -490,19 +870,35 @@ void main()
     }
 
     vec3 mul_res  = (col * weights + col2 * weights2).rgb * vec3(cval);
+    
+    // Shadow mask
+    // original code; just makes a giant phosphor here
+    xy = fract(vTexCoord.xy * u_quad_dims.xy / u_tex_size1.xy);
 
-    // dot-mask emulation:
-    // Output pixels are alternately tinted green and magenta.
-    vec3 dotMaskWeights = mix(
-        vec3(1.0, 1.0 - registers.DOTMASK, 1.0),
-        vec3(1.0 - registers.DOTMASK, 1.0, 1.0 - registers.DOTMASK),
-        floor(mod(gl_FragCoord.x, 2.0))
-    );
-      
-    mul_res *= dotMaskWeights;
+    // use subpixel mask code instead of LUTs
+    vec4 mask = vec4(1.0);
+    float alpha;
+    if(registers.vertical_scanlines < 0.5)
+      mask = vec4(mask_weights_alpha(vTexCoord.xy * global.OutputSize.xy, 1., int(registers.mask_type), alpha), 1.0);
+    else
+      mask = vec4(mask_weights_alpha(vTexCoord.yx * global.OutputSize.yx, 1., int(registers.mask_type), alpha), 1.0);
+    mask.a = alpha;
+
+    // count of total bright pixels is encoded in the mask's alpha channel
+    float nbright = 255.0 - 255.0*mask.a;
+    // fraction of bright pixels in the mask
+    float fbright = nbright / ( u_tex_size1.x * u_tex_size1.y );
+    // average darkening factor of the mask
+    float aperture_average = mix(1.0-DOTMASK.x*(1.0-DOTMASK_brightboost.x), 1.0, fbright);
+    // colour of dark mask pixels
+    vec3 clow = vec3(1.0-DOTMASK.x) * mul_res + vec3(DOTMASK.x*(DOTMASK_brightboost.x)) * mul_res * mul_res;
+    float ifbright = 1.0 / fbright;
+    // colour of bright mask pixels
+    vec3 chi = vec3(ifbright*aperture_average) * mul_res - vec3(ifbright - 1.0) * clow;
+    vec3 cout = mix(clow,chi,mask.rgb); // mask texture selects dark vs bright
 
     // Convert the image gamma for display on our output device.
-    mul_res = pow(mul_res, vec3(1.0 / registers.monitorgamma));
+    mul_res = pow(cout, vec3(1.0 / registers.monitorgamma));
 
     FragColor = vec4(mul_res, 1.0);
 }


### PR DESCRIPTION
Bring the 20 masks from the deluxe version into standard crt-geom.
Masks work for the vertical scanlines option as well.
Default to the old dotmask (mask 1) and keeps the DOTMASK parameter for compatibility with presets.