### PR TITLE
build: Enable building cross-platform; don't install git history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ all:
 
 install:
 	mkdir -p $(DESTDIR)$(INSTALLDIR)
-	cp -ar -t $(DESTDIR)$(INSTALLDIR) *
-	rm -f $(DESTDIR)$(INSTALLDIR)/Makefile \
-		$(DESTDIR)$(INSTALLDIR)/configure
+	cp -r ./. $(DESTDIR)$(INSTALLDIR)
+	rm -f $(DESTDIR)$(INSTALLDIR)/Makefile
+	rm -f $(DESTDIR)$(INSTALLDIR)/configure
+	rm -f $(DESTDIR)$(INSTALLDIR)/gitlab-ci.yml
+	rm -rf $(DESTDIR)$(INSTALLDIR)/.git
 
 test-install: all
 	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
* Don't use the `-t` option of `cp`, which is not available on all platforms/environments
* Don't copy the entire contents of `.git` and the CI routines

Noticed these issues while doing some downstream work for ares pulling down the shaders.