### PR TITLE
build: fix .gitlab-ci.yml removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 	cp -r ./. $(DESTDIR)$(INSTALLDIR)
 	rm -f $(DESTDIR)$(INSTALLDIR)/Makefile
 	rm -f $(DESTDIR)$(INSTALLDIR)/configure
-	rm -f $(DESTDIR)$(INSTALLDIR)/gitlab-ci.yml
+	rm -f $(DESTDIR)$(INSTALLDIR)/.gitlab-ci.yml
 	rm -rf $(DESTDIR)$(INSTALLDIR)/.git
 
 test-install: all


### PR DESCRIPTION
Instead of deleting .gitlab-ci.yml after installing into INSTALLDIR, the target tried to delete gitlab-ci.yml (without dot).