### PR TITLE
fix a bunch of shaders that break on d3d12

### DIFF
--- a/bezel/Mega_Bezel/shaders/hyllian/crt-super-xbr/crt-hyllian-sinc-curvature.slang
+++ b/bezel/Mega_Bezel/shaders/hyllian/crt-super-xbr/crt-hyllian-sinc-curvature.slang
@@ -66,7 +66,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 layout(set = 0, binding = 3) uniform sampler2D InfoCachePass;

--- a/crt/shaders/crt-lottes-multipass/bloompass-glow.slang
+++ b/crt/shaders/crt-lottes-multipass/bloompass-glow.slang
@@ -65,7 +65,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 layout(set = 0, binding = 3) uniform sampler2D ORIG_LINEARIZED;

--- a/crt/shaders/crt-lottes-multipass/bloompass.slang
+++ b/crt/shaders/crt-lottes-multipass/bloompass.slang
@@ -65,7 +65,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/crt/shaders/crt-lottes-multipass/scanpass-glow.slang
+++ b/crt/shaders/crt-lottes-multipass/scanpass-glow.slang
@@ -67,7 +67,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 layout(set = 0, binding = 3) uniform sampler2D ORIG_LINEARIZED;

--- a/crt/shaders/crt-lottes-multipass/scanpass.slang
+++ b/crt/shaders/crt-lottes-multipass/scanpass.slang
@@ -65,7 +65,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 layout(set = 0, binding = 3) uniform sampler2D BloomPass;

--- a/crt/shaders/crt-super-xbr/crt-custom.slang
+++ b/crt/shaders/crt-super-xbr/crt-custom.slang
@@ -64,7 +64,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/crt/shaders/hyllian/crt-hyllian-pass0.slang
+++ b/crt/shaders/hyllian/crt-hyllian-pass0.slang
@@ -135,7 +135,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/crt/shaders/hyllian/crt-hyllian-pass1.slang
+++ b/crt/shaders/hyllian/crt-hyllian-pass1.slang
@@ -98,7 +98,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/crt/shaders/hyllian/crt-hyllian-sinc-pass0.slang
+++ b/crt/shaders/hyllian/crt-hyllian-sinc-pass0.slang
@@ -143,7 +143,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/downsample/mixed-res/hooks/mixed-res-4x-append.slangp
+++ b/downsample/mixed-res/hooks/mixed-res-4x-append.slangp
@@ -1,9 +1,15 @@
-shaders = "1"
+shaders = "3"
 
-shader0 =  "../../shaders/mixed-res/output.slang"
-filter_linear0 =  false
-wrap_mode0 =  "clamp_to_border"
-scale_type0 =  "source"
-scale0 =  "1.000000"
+shader0 = "../../../stock.slang"
+alias0 = HiresSource
+
+shader1 = "../../../stock.slang"
+alias1 = BlurSource
+
+shader2 =  "../../shaders/mixed-res/output.slang"
+filter_linear2 =  false
+wrap_mode2 =  "clamp_to_border"
+scale_type2 =  "source"
+scale2 =  "1.000000"
 
 B_HL = "0.0" 

--- a/downsample/shaders/mixed-res/cheap-sharpen-tweaked.slang
+++ b/downsample/shaders/mixed-res/cheap-sharpen-tweaked.slang
@@ -65,7 +65,6 @@ void main()
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 1) in vec4 t1;
 layout(location = 2) in vec4 t2;
-layout(location = 3) in vec4 t3;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/edge-smoothing/eagle/shaders/2xsai.slang
+++ b/edge-smoothing/eagle/shaders/2xsai.slang
@@ -42,7 +42,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in  vec2 vTexCoord;
-layout(location = 1) in  vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/edge-smoothing/xsal/shaders/2xsal-level2-xbr.slang
+++ b/edge-smoothing/xsal/shaders/2xsal-level2-xbr.slang
@@ -49,7 +49,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in  vec2 vTexCoord;
-layout(location = 1) in  vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/handheld/shaders/color/gba-color-old.slang
+++ b/handheld/shaders/color/gba-color-old.slang
@@ -27,7 +27,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/handheld/shaders/color/gbc-dev.slang
+++ b/handheld/shaders/color/gbc-dev.slang
@@ -27,7 +27,6 @@ void main()
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
-layout(location = 1) in vec2 FragCoord;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/nes_raw_palette/shaders/cgwg-famicom-geom/crt-geom-famicom.slang
+++ b/nes_raw_palette/shaders/cgwg-famicom-geom/crt-geom-famicom.slang
@@ -6,7 +6,7 @@ layout(push_constant) uniform Push
 	vec4 OriginalSize;
 	vec4 OutputSize;
 	uint FrameCount;
-	float CURVATURE_toggle, CRTgamma, overscan_x, overscan_y, distance, radius, tiltangle_x, tiltangle_y, cornersize, cornersmooth;
+	float CURVATURE_toggle, CRTgamma, overscan_x, overscan_y, distance_cgwg, radius, tiltangle_x, tiltangle_y, cornersize, cornersmooth;
 } params;
 
 #pragma parameter CURVATURE_toggle "Curvature Toggle" 1.0 0.0 1.0 1.0
@@ -18,8 +18,8 @@ layout(push_constant) uniform Push
 #pragma parameter overscan_x "Overscan X" 1.0 0.0 2.0 0.01
 #pragma parameter overscan_y "Overscan Y" 1.0 0.0 2.0 0.01
 #define overscan vec2(params.overscan_x, params.overscan_y)
-#pragma parameter distance "Viewing Distance" 2.0 0.1 5.0 0.1
-#define distance params.distance
+#pragma parameter distance_cgwg "Viewing Distance" 2.0 0.1 5.0 0.1
+#define distance_cgwg params.distance_cgwg
 // radius of curvature
 #pragma parameter radius "Curvature Radius" 2.0 0.1 5.0 0.1
 #define radius params.radius
@@ -48,7 +48,7 @@ layout(location = 0) out vec2 texCoord;
 layout(location = 1) out vec3 stretch;
 
 const vec2 aspect = vec2(1.0, 0.75);
-float d = distance;
+float d = distance_cgwg;
 float R = radius;
 vec2 sinangle = sin(tiltangle);
 vec2 cosangle = cos(tiltangle);
@@ -133,7 +133,7 @@ layout(set = 0, binding = 2) uniform sampler2D Source;
 const vec2 aspect = vec2(1.0, 0.75);
 // lengths are measured in units of (approximately) the width of the monitor
 // simulated distance from viewer to monitor
-float d = distance;
+float d = distance_cgwg;
 float R = radius;
 
 vec2 sinangle = sin(tiltangle);

--- a/sharpen/shaders/cheap-sharpen.slang
+++ b/sharpen/shaders/cheap-sharpen.slang
@@ -62,7 +62,6 @@ void main()
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 1) in vec4 t1;
 layout(location = 2) in vec4 t2;
-layout(location = 3) in vec4 t3;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 

--- a/test/decode-format.slang
+++ b/test/decode-format.slang
@@ -3,6 +3,7 @@
 layout(std140, set = 0, binding = 0) uniform UBO
 {
    mat4 MVP;
+   vec4 SourceSize;
 } global;
 
 #pragma stage vertex
@@ -23,6 +24,7 @@ layout(set = 0, binding = 1) uniform usampler2D Source;
 
 void main()
 {
-   vec4 current = unpackUnorm4x8(texture(Source, vTexCoord).r);
+// Sampling non-float textures is not supported in HLSL, so use texelFetch() instead of texture()
+   vec4 current = unpackUnorm4x8(texelFetch(Source, ivec2(vTexCoord.xy * global.SourceSize.xy), 0).r);
    FragColor = current;
 }


### PR DESCRIPTION
This should fix all of the ones listed in https://github.com/libretro/slang-shaders/issues/666 except for the one koko-aio preset and the noncausal feedback test shader that breaks intentionally.