### PR TITLE
Authentic GBC v2.2

### DIFF
--- a/handheld/authentic_gbc_single_pass.slangp
+++ b/handheld/authentic_gbc_single_pass.slangp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/authentic_gbc/authentic_gbc_single_pass.slang
+filter_linear0 = false
+scale_type0 = viewport

--- a/handheld/shaders/authentic_gbc/authentic_gbc_single_pass.slang
+++ b/handheld/shaders/authentic_gbc/authentic_gbc_single_pass.slang
@@ -1,27 +1,6 @@
 #version 450
 
-/*
-    Authentic GBC by fishku
-    Copyright (C) 2024-2025
-    Public domain license (CC0)
-
-    Attempts to render GBC subpixels authentically.
-
-    Reference photos:
-    - https://gbcc.dev/technology/subpixels.jpg
-
-    Inspired by:
-    -
-   https://www.reddit.com/r/AnaloguePocket/comments/1azaxgd/ive_made_some_improvements_to_my_analogue_pocket/
-
-    Changelog:
-    v2.2: Add single pass preset to sync with GLSL v2.2.
-    v2.1: Fix quantization issue introduced by last version.
-    v2.0: Add smoothed rectangle rendering for better AA. Add subpixel rendering. Optimize. Improve
-          numerical stability. Split out "fast" shader. Tweak defaults to be brighter and smoother.
-    v1.1: Use OriginalSize instead of SourceSize to better work with combined presets.
-    v1.0: Initial release.
-*/
+// See the main shader file for copyright and other information.
 
 #include "parameters.inc"
 #include "shared.inc"
@@ -105,6 +84,12 @@ void main() {
         texture(Source, (tx_coord_i + tx_coord_offs[1] + 0.5) * param.OriginalSize.zw).rgb,
         texture(Source, (tx_coord_i + tx_coord_offs[2] + 0.5) * param.OriginalSize.zw).rgb,
         texture(Source, (tx_coord_i + tx_coord_offs[3] + 0.5) * param.OriginalSize.zw).rgb};
+    
+    // Single pass version: Apply linearization.
+    samples[0] = pow(samples[0], vec3(2.2));
+    samples[1] = pow(samples[1], vec3(2.2));
+    samples[2] = pow(samples[2], vec3(2.2));
+    samples[3] = pow(samples[3], vec3(2.2));
 
     // The four nearest texels define a set of vector graphics which are rasterized.
     // The coordinate origin is shifted to px_coord = tx_coord * tx_to_px.

--- a/handheld/shaders/authentic_gbc/parameters.inc
+++ b/handheld/shaders/authentic_gbc/parameters.inc
@@ -1,7 +1,7 @@
 // See the main shader file for copyright and other information.
 
 // clang-format off
-#pragma parameter AUTH_GBC_SETTINGS "=== Authentic GBC v2.1 settings ===" 0.0 0.0 1.0 1.0
+#pragma parameter AUTH_GBC_SETTINGS "=== Authentic GBC v2.2 settings ===" 0.0 0.0 1.0 1.0
 #pragma parameter AUTH_GBC_BRIG "Add brightness" 0.6 0.0 1.0 0.05
 #pragma parameter AUTH_GBC_BLUR "Anti-banding smoothing" 0.3 0.0 1.0 0.05
 #pragma parameter AUTH_GBC_SUBPX "Enable subpixel rendering" 0.0 0.0 1.0 1.0

--- a/handheld/shaders/authentic_gbc/to_lin.slang
+++ b/handheld/shaders/authentic_gbc/to_lin.slang
@@ -1,6 +1,6 @@
 #version 450
 
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 layout(std140, set = 0, binding = 0) uniform UBO { mat4 MVP; }
 global;

--- a/handheld/shaders/authentic_gbc/to_lin_fast.slang
+++ b/handheld/shaders/authentic_gbc/to_lin_fast.slang
@@ -1,6 +1,6 @@
 #version 450
 
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 layout(std140, set = 0, binding = 0) uniform UBO { mat4 MVP; }
 global;

--- a/pixel-art-scaling/shaders/pixel_aa/parameters.inc
+++ b/pixel-art-scaling/shaders/pixel_aa/parameters.inc
@@ -1,4 +1,4 @@
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 // clang-format off
 #pragma parameter PIX_AA_SETTINGS "=== Pixel AA v1.9 settings ===" 0.0 0.0 1.0 1.0

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa_fast.slang
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa_fast.slang
@@ -1,6 +1,6 @@
 #version 450
 
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 layout(push_constant) uniform Push {
   vec4 SourceSize;

--- a/pixel-art-scaling/shaders/pixel_aa/pixel_aa_single_pass.slang
+++ b/pixel-art-scaling/shaders/pixel_aa/pixel_aa_single_pass.slang
@@ -1,6 +1,6 @@
 #version 450
 
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 #include "parameters.inc"
 #include "shared.inc"

--- a/pixel-art-scaling/shaders/pixel_aa/shared.inc
+++ b/pixel-art-scaling/shaders/pixel_aa/shared.inc
@@ -1,4 +1,4 @@
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 // Similar to smoothstep, but has a configurable slope at x = 0.5.
 // Original smoothstep has a slope of 1.5 at x = 0.5

--- a/pixel-art-scaling/shaders/pixel_aa/to_lin.slang
+++ b/pixel-art-scaling/shaders/pixel_aa/to_lin.slang
@@ -1,6 +1,6 @@
 #version 450
 
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 layout(std140, set = 0, binding = 0) uniform UBO { mat4 MVP; }
 global;

--- a/pixel-art-scaling/shaders/pixel_aa/to_lin_fast.slang
+++ b/pixel-art-scaling/shaders/pixel_aa/to_lin_fast.slang
@@ -1,6 +1,6 @@
 #version 450
 
-// See main shader file for copyright and other information.
+// See the main shader file for copyright and other information.
 
 layout(std140, set = 0, binding = 0) uniform UBO { mat4 MVP; }
 global;


### PR DESCRIPTION
Brings back some changes from https://github.com/libretro/glsl-shaders/pull/506 to Slang.

(Thanks for merging these so quickly! This should hopefully be the last of these ping-pong PRs to maintain these Slang and GLSL shaders.)