### PR TITLE
fix fxaa preset

### DIFF
--- a/anti-aliasing/fxaa+linear.slangp
+++ b/anti-aliasing/fxaa+linear.slangp
@@ -1,6 +1,9 @@
-shaders = 1
+shaders = 2
 
 shader0 = shaders/fxaa.slang
 filter_linear0 = true
 scale_type0 = source
 scale0 = 1.0
+
+shader1 = ../stock.slang
+filter_linear1 = true


### PR DESCRIPTION
Sample image:
![sample](https://github.com/user-attachments/assets/12cd6047-2d91-4016-b4d6-beeb71a65f59)

Old FXAA preset at 1x: (this looks fine)
![oldfxaa](https://github.com/user-attachments/assets/09f8ae70-6115-4b49-b7ba-32af984b0fd5)

Old FXAA preset at 4x: (notice the strange edges)
![oldfxaa4x](https://github.com/user-attachments/assets/eedce349-9211-4094-a527-81b679c52a52)

New FXAA preset at 1x: (looks the same as old at 1x)
![newfxaa](https://github.com/user-attachments/assets/d9d8f80a-fa91-46b6-b1b7-d246ca0aa675)

New FXAA preset at 4x:
![newfxaa4x](https://github.com/user-attachments/assets/3c9589db-52cf-43f4-8857-351dc5b66ca4)

Also added a preset with bilinear as a final pass (4x):
![newfxaalinear4x](https://github.com/user-attachments/assets/e2416f40-d400-462e-8428-597cdf4640e5)
