### PR TITLE
Updated 'screen_offset' and added 'gameboy-advance-dot-matrix-sepia'

### DIFF
--- a/handheld/gameboy-advance-dot-matrix-sepia.slangp
+++ b/handheld/gameboy-advance-dot-matrix-sepia.slangp
@@ -1,0 +1,41 @@
+shaders = 5
+
+shader0 = shaders/gameboy/shader-files/gb-pass0.slang
+filter_linear0 = false
+scale_type0 = viewport
+scale0 = 1.0
+alias0 = "PASS0"
+color_toggle = "1.000000"
+baseline_alpha = "1.000000"
+response_time = "0.000000"
+contrast = "1.000000"
+
+shader1 = shaders/gameboy/shader-files/gb-pass1.slang
+filter_linear1 = false
+scale_type1 = source
+scale1 = 1.0
+alias1 = "PASS1"
+
+shader2 = shaders/gameboy/shader-files/gb-pass2.slang
+filter_linear2 = false
+scale_type2 = source
+scale2 = 1.0
+alias2 = "PASS2"
+
+shader3 = shaders/gameboy/shader-files/gb-pass3.slang
+filter_linear3 = false
+scale_type3 = source
+scale3 = 1.0
+alias3 = "PASS3"
+
+shader4 = shaders/gameboy/shader-files/gb-pass4.slang
+filter_linear4 = false
+scale_type4 = source
+scale4 = 1.0
+alias4 = "PASS4"
+
+textures = COLOR_PALETTE;BACKGROUND
+COLOR_PALETTE = shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true

--- a/handheld/shaders/gameboy/shader-files/gb-pass4.slang
+++ b/handheld/shaders/gameboy/shader-files/gb-pass4.slang
@@ -55,10 +55,10 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #pragma parameter shadow_offset_y "Shadow Offset Vert" 1.0 -5.0 5.0 0.5
 
 // Screen offset - [-infinity, infinity] [DEFAULT: 0]
-#pragma parameter screen_offset_x "Screen Offset Horiz" 0.0 -5.0 5.0 0.5
+#pragma parameter screen_offset_x "Screen Offset Horiz" -1.0 -5.0 5.0 0.5
 
 // Screen offset - [-infinity, infinity] [DEFAULT: 0]
-#pragma parameter screen_offset_y "Screen Offset Vert" 0.0 -5.0 5.0 0.5    
+#pragma parameter screen_offset_y "Screen Offset Vert" -1.0 -5.0 5.0 0.5    
 
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //

--- a/presets/gameboy-advance-dot-matrix-sepia.slangp
+++ b/presets/gameboy-advance-dot-matrix-sepia.slangp
@@ -1,6 +1,6 @@
 shaders = 5
 
-shader0 = shaders/gameboy/shader-files/gb-pass0.slang
+shader0 = ../handheld/shaders/gameboy/shader-files/gb-pass0.slang
 filter_linear0 = false
 scale_type0 = viewport
 scale0 = 1.0
@@ -10,32 +10,32 @@ baseline_alpha = "1.000000"
 response_time = "0.000000"
 contrast = "1.000000"
 
-shader1 = shaders/gameboy/shader-files/gb-pass1.slang
+shader1 = ../handheld/shaders/gameboy/shader-files/gb-pass1.slang
 filter_linear1 = false
 scale_type1 = source
 scale1 = 1.0
 alias1 = "PASS1"
 
-shader2 = shaders/gameboy/shader-files/gb-pass2.slang
+shader2 = ../handheld/shaders/gameboy/shader-files/gb-pass2.slang
 filter_linear2 = false
 scale_type2 = source
 scale2 = 1.0
 alias2 = "PASS2"
 
-shader3 = shaders/gameboy/shader-files/gb-pass3.slang
+shader3 = ../handheld/shaders/gameboy/shader-files/gb-pass3.slang
 filter_linear3 = false
 scale_type3 = source
 scale3 = 1.0
 alias3 = "PASS3"
 
-shader4 = shaders/gameboy/shader-files/gb-pass4.slang
+shader4 = ../handheld/shaders/gameboy/shader-files/gb-pass4.slang
 filter_linear4 = false
 scale_type4 = source
 scale4 = 1.0
 alias4 = "PASS4"
 
 textures = COLOR_PALETTE;BACKGROUND
-COLOR_PALETTE = shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE = ../handheld/shaders/gameboy/resources/sample-palettes/gbp-palette.png
 COLOR_PALETTE_linear = false
-BACKGROUND = shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND = ../handheld/shaders/gameboy/resources/sample-bgs/paper-bg.png
 BACKGROUND_linear = true


### PR DESCRIPTION
## Updated 'screen_offset' value to fix issue #96 
By default, both 'screen_offset' values are now -1.0 to eliminate the 1px line on the left and top of the image when using integer scaling mode with the gameboy shaders. This is hard to take a screenshot of, but use any of the 'gameboy' shaders and turn 'Integer Scaling' on to see the issue.

## Added 'gameboy-advance-dot-matrix-sepia'
Uses the 'gameboy-pocket' and 'gameboy-color-dot-matrix' background to create a sepia tone image. 
![Advance Wars 2 - Black Hole Rising-250223-223253](https://github.com/user-attachments/assets/0a5b5a01-b357-4943-9291-6836527d92e4)
_'gameboy-advance-dot-matrix-sepia'_
![Advance Wars 2 - Black Hole Rising-250223-223236](https://github.com/user-attachments/assets/1b2df4ad-50e6-46d1-9242-75de891bd610)
_'gameboy-advance-dot-matrix'_