### PR TITLE
Add Phosphor-Persistence shaders

### DIFF
--- a/crt/phosphor-persistence.slangp
+++ b/crt/phosphor-persistence.slangp
@@ -1,0 +1,22 @@
+shaders = 3
+
+shader0 = shaders/phosphor-persistence/phosphor-apply.slang
+alias0 = internal1
+filter_linear0 = false
+scale_type0 = source
+scale0 = 1.0
+
+shader1 = shaders/phosphor-persistence/phosphor-update.slang
+alias1 = phosphor
+filter_linear1 = false
+scale_type1 = source  
+scale1 = 1.0
+
+shader2 = shaders/phosphor-persistence/passthrough.slang
+alias2 = internal2
+filter_linear2 = false
+scale_type2 = source  
+scale2 = 1.0
+
+phosphor_power = "1.800000"
+phosphor_amplitude = "0.040000"

--- a/crt/shaders/phosphor-persistence/passthrough.slang
+++ b/crt/shaders/phosphor-persistence/passthrough.slang
@@ -1,0 +1,42 @@
+#version 450
+
+/*  passthrough-pass2.slang shader
+
+    Based on stock.slang shader. A passthrough shader.
+
+
+*/
+
+layout(push_constant) uniform Push
+{
+	vec4 SourceSize;
+	vec4 OriginalSize;
+	vec4 OutputSize;
+	uint FrameCount;
+} params;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+	mat4 MVP;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D internal1;
+
+void main()
+{
+   FragColor = vec4(texture(internal1, vTexCoord).rgb, 1.0);
+}

--- a/crt/shaders/phosphor-persistence/phosphor-apply.slang
+++ b/crt/shaders/phosphor-persistence/phosphor-apply.slang
@@ -1,0 +1,71 @@
+#version 450
+
+/*  Phosphot Persistence - code copied from crt-geom-deluxe
+ *
+ *  Copyright (C) 2010-2016 cgwg, Themaister and DOLLS
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ */
+
+layout(push_constant) uniform Push
+{
+	float phosphor_power;
+	float phosphor_amplitude;
+} params;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+	vec4 SourceSize;
+	vec4 OriginalSize;
+	vec4 OutputSize;
+	uint FrameCount;
+    vec4 FinalViewportSize;
+    vec4 internal1Size;
+	mat4 MVP;
+} global;
+
+#pragma parameter phosphor_power "Phosphor decay power" 1.2 0.5 3.0 0.05
+#pragma parameter phosphor_amplitude "Phosphor persistence amplitude" 0.04 0.0 0.2 0.01
+
+#define phosphor_power params.phosphor_power
+#define phosphor_amplitude params.phosphor_amplitude
+
+const float gamma = 2.2;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D PassFeedback1;
+
+void main()
+{
+   vec4 screen = texture(Source, vTexCoord);
+   vec4 phosphor = texture(PassFeedback1, vTexCoord);
+   
+   vec3 cscrn = pow(screen.rgb, vec3(gamma));
+   vec3 cphos = pow(phosphor.rgb, vec3(gamma));
+   
+   // encode the upper 2 bits of the time elapsed in the lower 2 bits of b
+   float t = 255.0*phosphor.a + fract(phosphor.b*255.0/4.0)*1024.0;
+
+   cphos *= vec3( phosphor_amplitude * pow(t,-phosphor_power) );
+   
+   vec3 col = pow(cscrn + cphos, vec3(1.0/gamma));
+   
+   FragColor = vec4(col, 1.0);
+}

--- a/crt/shaders/phosphor-persistence/phosphor-update.slang
+++ b/crt/shaders/phosphor-persistence/phosphor-update.slang
@@ -1,0 +1,75 @@
+#version 450
+#pragma name phosphor
+
+/*  Phosphot Persistence - code copied from crt-geom-deluxe
+ *
+ *  Copyright (C) 2010-2016 cgwg, Themaister and DOLLS
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ */
+
+
+layout(push_constant) uniform Push
+{
+	float phosphor_power;
+	float phosphor_amplitude;
+} params;
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+	vec4 SourceSize;
+	vec4 OriginalSize;
+	vec4 OutputSize;
+	uint FrameCount;
+    vec4 FinalViewportSize;
+    vec4 internal1Size;
+	mat4 MVP;
+} global;
+
+#pragma parameter phosphor_power "Phosphor decay power" 1.2 0.5 3.0 0.05
+#pragma parameter phosphor_amplitude "Phosphor persistence amplitude" 0.04 0.0 0.2 0.01
+
+#define phosphor_power params.phosphor_power
+#define phosphor_amplitude params.phosphor_amplitude
+
+const float gamma = 2.2;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+   gl_Position = global.MVP * Position;
+   vTexCoord = TexCoord * 1.0001;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 3) uniform sampler2D phosphorFeedback;
+
+void main()
+{
+   vec4 screen = texture(Source, vTexCoord);
+   vec4 phosphor = texture(phosphorFeedback, vTexCoord);
+   
+   vec3 lum = vec3(0.299,0.587,0.114);
+   float bscrn = dot(pow(screen.rgb,vec3(gamma)),lum);
+   float bphos = dot(pow(phosphor.rgb,vec3(gamma)),lum);
+   // encode the upper 2 bits of the time elapsed in the lower 2 bits of b
+   float t = 1.0 + 255.0*phosphor.a + fract(phosphor.b*255.0/4.0)*1024.0;
+
+   bphos = ( t > 1023.0 ? 0.0 : bphos*pow(t,-phosphor_power) );
+
+   FragColor = ( bscrn >= bphos ?
+      vec4(screen.rg,floor(screen.b*255.0/4.0)*4.0/255.0,1.0/255.0)
+      : vec4(phosphor.rg,
+         (floor(phosphor.b*255.0/4.0)*4.0 + floor(t/256.0))/255.0,
+         fract(t/256.0)*256.0/255.0 ) );
+}


### PR DESCRIPTION
- These shaders were detached from crt-geom-deluxe (license inside them) in a way it can be prepended to any other crt-shader preset.