### PR TITLE
Adds fakelottes-ntsc-composite and fakelottes-ntsc-svideo

### DIFF
--- a/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
@@ -1,0 +1,30 @@
+shaders = 5
+
+shader0 = ../../stock.slang
+alias0 = PrePass0
+
+shader1 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass1.slang
+alias1 = NPass1
+scale_type_x1 = source
+scale_type_y1 = source
+scale_x1 = 4.0
+scale_y1 = 1.0
+float_framebuffer1 = true
+filter_linear1 = false
+
+shader2 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass2.slang
+filter_linear2 = true
+float_framebuffer2 = true
+scale_type2 = source
+scale_x2 = 0.5
+scale_y2 = 1.0
+
+shader3 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass3.slang
+filter_linear3 = true
+scale_type3 = source
+scale_x3 = 1.0
+scale_y3 = 1.0
+
+shader4 = ../../crt/shaders/fakelottes.slang
+filter_linear4 = true
+scale_type4 = viewport

--- a/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
@@ -1,0 +1,33 @@
+shaders = 5
+
+shader0 = ../../stock.slang
+alias0 = PrePass0
+
+shader1 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass1.slang
+alias1 = NPass1
+scale_type_x1 = source
+scale_type_y1 = source
+scale_x1 = 4.0
+scale_y1 = 1.0
+float_framebuffer1 = true
+filter_linear1 = false
+
+shader2 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass2.slang
+filter_linear2 = true
+float_framebuffer2 = true
+scale_type2 = source
+scale_x2 = 0.5
+scale_y2 = 1.0
+
+shader3 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass3.slang
+filter_linear3 = true
+scale_type3 = source
+scale_x3 = 1.0
+scale_y3 = 1.0
+
+shader4 = ../../crt/shaders/fakelottes.slang
+filter_linear4 = true
+scale_type4 = viewport
+
+cust_artifacting = "0.000000"
+cust_fringing = "0.000000"


### PR DESCRIPTION
This is my first PR, but due to personal issues I don't have much free time to dedicate to this, so I hope I'm doing everything right.

Adds the fakelottes-ntsc-composite and fakelottes-ntsc-svideo presets, which basically mixes the crt/fakelottes.slangp with ntsc/ntsc-adaptive.slangp presets. The fakelottes-ntsc-svideo variant just disables composite video artifacts.

This runs at full speed even on a cheap Android I had, so I thought it might be interesting for those using RetroArch on weak hardware if it gets merged.

![Captura de tela de 2025-06-24 17-49-56](https://github.com/user-attachments/assets/94f93052-a395-4dfc-a31a-23b3d9219d30)
![Captura de tela de 2025-06-24 17-57-33](https://github.com/user-attachments/assets/2b4e629e-e89a-4200-9a71-5aa81090f057)