### PR TITLE
Fix for older Retro Arch version without frametime uniforms

### DIFF
--- a/crt/shaders/crt-yah/common/frame-helper.h
+++ b/crt/shaders/crt-yah/common/frame-helper.h
@@ -13,8 +13,12 @@
 #endif
 
 #ifndef FRAME_TIME_DELTA
-    // The frame time delta (in microseconds).
-    #define FRAME_TIME_DELTA global.FrameTimeDelta
+    // The frame time delta (in microseconds).    
+    #ifdef _HAS_FRAMETIME_UNIFORMS
+        #define FRAME_TIME_DELTA global.FrameTimeDelta
+    #else
+        #define FRAME_TIME_DELTA BASE_FRAME_TIME_DELTA
+    #endif
 #endif
 
 #ifndef FRAME_COUNT


### PR DESCRIPTION
This PR fixes the below shader compile error occurring in older Retro Arch versions, where the `FrameTimeDelta` uniform is not available.

> [ERROR] [slang]: Unknown semantic found.
> [ERROR] [slang]: Failed to reflect SPIR-V. Resource usage is inconsistent with expectations.

Tested with Retro Arch v1.16.0