### PR TITLE
Fix DX11 "unable to unroll loop" compile error

### DIFF
--- a/crt/shaders/crt-yah/blur-horizontal.slang
+++ b/crt/shaders/crt-yah/blur-horizontal.slang
@@ -81,16 +81,22 @@ void main()
     float diffusion = Diffusion / (Multiple * Multiple);
 
     // scale tabs (can be quite in-performant for high resolutions)
-    int tabs = int(Tabs * Multiple);
-    for (int i = -tabs; i <= tabs; i++)
+    float tabs = Tabs * Multiple;
+    float n = -tabs;
+    int i = 0;
+    do
     {
         vec2 texCoord = TexCoord;
-        texCoord.x += i * global.SourceSize.z;
+        texCoord.x += n * global.SourceSize.z;
 
-        float k = exp(-diffusion * i * i);
+        float k = exp(-diffusion * n * n);
         color += k * INPUT(texture(Source, texCoord).rgb);
         sum += k;
+
+        n += 1.0;
+        i += 1;
     }
+    while (n <= tabs && i <= 64); // break after max. 64 iterations
 
     FragColor = vec4(OUTPUT(color / sum), 1.0);
 }

--- a/crt/shaders/crt-yah/blur-vertical.slang
+++ b/crt/shaders/crt-yah/blur-vertical.slang
@@ -88,16 +88,22 @@ void main()
     float diffusion = Diffusion / (Multiple * Multiple);
 
     // scale tabs (can be quite in-performant for high resolutions)
-    int tabs = int(Tabs * Multiple);
-    for (int i = -tabs; i <= tabs; i++)
+    float tabs = Tabs * Multiple;
+    float n = -tabs;
+    int i = 0;
+    do
     {
         vec2 texCoord = TexCoord;
-        texCoord.y += i * global.SourceSize.w;
+        texCoord.y += n * global.SourceSize.w;
 
-        float k = exp(-diffusion * i * i);
+        float k = exp(-diffusion * n * n);
         color += k * INPUT(texture(Source, texCoord).rgb);
         sum += k;
+
+        n += 1.0;
+        i += 1;
     }
+    while (n <= tabs && i <= 64); // break after max. 64 iterations
 
     FragColor = vec4(OUTPUT(color / sum), 1.0);
 }


### PR DESCRIPTION
This PR fixes the following DX11 compile error.
> crt-yah\blur-horizontal.slang.ps.hlsl(151,5-38): error X3511: unable to unroll loop, loop does not appear to terminate in a timely manner (673 iterations) or unrolled loop is too large, use the [unroll(n)] attribute to force an exact higher number

The for-loop has been replaced by a do/while-loop with safety break after 64 iterations.

To be honest, I don't know why the safety break is necessary, because other blur shader use a similar loop and don't fail to compile on my machine.