### PR TITLE
Use boolean for updated super-xbr shaders

### DIFF
--- a/edge-smoothing/xbr/super-xbr-fast.slangp
+++ b/edge-smoothing/xbr/super-xbr-fast.slangp
@@ -35,7 +35,7 @@ scale_type4 = "viewport"
 scale4 = "1.000000"
 
 shader5 = "shaders/support/deblur-fast.slang"
-filter_linear5 = linear
+filter_linear5 = true
 wrap_mode5 = clamp_to_edge
 
 XBR_EDGE_STR_P0 = "0.400000"

--- a/edge-smoothing/xbr/super-xbr.slangp
+++ b/edge-smoothing/xbr/super-xbr.slangp
@@ -35,7 +35,7 @@ scale_type4 = "viewport"
 scale4 = "1.000000"
 
 shader5 = "shaders/support/deblur-fast.slang"
-filter_linear5 = linear
+filter_linear5 = true
 wrap_mode5 = clamp_to_edge
 
 XBR_EDGE_STR_P0 = "3.000000"


### PR DESCRIPTION
I think that was the intention behind #697.

Note that retroarch default to false for invalid boolean https://github.com/libretro/RetroArch/blob/master/libretro-common/file/config_file.c#L1205

So technically to keep current behaviour it should be `false` but since @Hyllian put `linear`there I presume the intention is `true`.

(Noticed this since the non-boolean is tripping up librashader)