### PR TITLE
Fix all presets to nearest plus change AR value

### DIFF
--- a/crt/crt-CreativeForce-Arcade.slangp
+++ b/crt/crt-CreativeForce-Arcade.slangp
@@ -1,11 +1,11 @@
-# crt-CreativeForce-Arcade.slangp
-
 shaders = 2
 
 shader0 = ../interpolation/shaders/lanczos16-AR.slang
-filter_linear0 = true
-scale_type0 = viewport
+filter_linear0 = false
+scale_type0    = viewport
+wrap_mode0     = clamp_to_border
 
 shader1 = shaders/CreativeForce/crt-CreativeForce-Arcade.slang
 filter_linear1 = false
-scale_type1 = viewport
+scale_type1    = viewport
+wrap_mode1     = clamp_to_border

--- a/crt/crt-CreativeForce-SharpSmooth.slangp
+++ b/crt/crt-CreativeForce-SharpSmooth.slangp
@@ -1,11 +1,11 @@
-# crt-CreativeForce-SharpSmooth.slangp
-
 shaders = 2
 
 shader0 = ../interpolation/shaders/lanczos16-AR.slang
-filter_linear0 = true
-scale_type0 = viewport
+filter_linear0 = false
+scale_type0    = viewport
+wrap_mode0     = clamp_to_border
 
 shader1 = shaders/CreativeForce/crt-CreativeForce-SharpSmooth.slang
 filter_linear1 = false
-scale_type1 = viewport
+scale_type1    = viewport
+wrap_mode1     = clamp_to_border

--- a/interpolation/lanczos16-AR.slangp
+++ b/interpolation/lanczos16-AR.slangp
@@ -1,2 +1,5 @@
 shaders = 1
 shader0 = shaders/lanczos16-AR.slang
+filter_linear0 = false
+scale_type0    = viewport
+wrap_mode0     = clamp_to_border

--- a/interpolation/shaders/lanczos16-AR.slang
+++ b/interpolation/shaders/lanczos16-AR.slang
@@ -29,7 +29,7 @@ This program is free software; you can redistribute it and/or
    the ~1-pixel up/left shift some drivers/backends exhibited.
 */
 
-#pragma parameter AR_STRENGTH "Anti-ringing Strength" 1.00 0.0 1.0 0.05
+#pragma parameter AR_STRENGTH "Anti-ringing Strength" 0.70 0.0 1.0 0.05
 
 layout(push_constant) uniform Push {
     vec4 SourceSize;   // xy = size, zw = 1/size

--- a/interpolation/shaders/lanczos16-AR.slang
+++ b/interpolation/shaders/lanczos16-AR.slang
@@ -29,7 +29,7 @@ This program is free software; you can redistribute it and/or
    the ~1-pixel up/left shift some drivers/backends exhibited.
 */
 
-#pragma parameter AR_STRENGTH "Anti-ringing Strength" 0.70 0.0 1.0 0.05
+#pragma parameter AR_STRENGTH "Anti-ringing Strength" 0.75 0.0 1.0 0.05
 
 layout(push_constant) uniform Push {
     vec4 SourceSize;   // xy = size, zw = 1/size


### PR DESCRIPTION
Quick fix to make sure the shaders open in nearest mode for best image quality. Only edited the 3 preset files, not the shaders themselves, aside from changing the default AR value for the lanczos16-AR shader. 