### PR TITLE
Update crt-CreativeForce-Arcade.slangp default AR value

### DIFF
--- a/crt/crt-CreativeForce-Arcade.slangp
+++ b/crt/crt-CreativeForce-Arcade.slangp
@@ -9,3 +9,6 @@ shader1 = shaders/CreativeForce/crt-CreativeForce-Arcade.slang
 filter_linear1 = false
 scale_type1    = viewport
 wrap_mode1     = clamp_to_border
+# Override AR strength for this preset only
+parameters = AR_STRENGTH
+AR_STRENGTH = 0.61


### PR DESCRIPTION
Optimized the default AR value for the Arcade shader preset as this is for pre-rendered 2d game art. Last tweak, I promise! Thank you!!