### PR TITLE
Update fakelottes-ntsc-composite and fakelottes-ntsc-svideo

### DIFF
--- a/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
@@ -1,30 +1,7 @@
-shaders = 5
+shaders = "3"
+shader0 = "../../crt/shaders/crt-consumer/linear.slang"
+shader1 = "../../crt/shaders/crt-consumer/ntsc_module.slang"
+shader2 = "../../crt/shaders/fakelottes.slang"
 
-shader0 = ../../stock.slang
-alias0 = PrePass0
-
-shader1 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass1.slang
-alias1 = NPass1
-scale_type_x1 = source
-scale_type_y1 = source
-scale_x1 = 4.0
-scale_y1 = 1.0
-float_framebuffer1 = true
-filter_linear1 = false
-
-shader2 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass2.slang
-filter_linear2 = true
-float_framebuffer2 = true
-scale_type2 = source
-scale_x2 = 0.5
-scale_y2 = 1.0
-
-shader3 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass3.slang
-filter_linear3 = true
-scale_type3 = source
-scale_x3 = 1.0
-scale_y3 = 1.0
-
-shader4 = ../../crt/shaders/fakelottes.slang
-filter_linear4 = true
-scale_type4 = viewport
+filter_linear2 = "true"
+scale_type2 = "viewport"

--- a/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
@@ -1,33 +1,9 @@
-shaders = 5
+shaders = "3"
+shader0 = "../../crt/shaders/crt-consumer/linear.slang"
+shader1 = "../../crt/shaders/crt-consumer/ntsc_module.slang"
+shader2 = "../../crt/shaders/fakelottes.slang"
 
-shader0 = ../../stock.slang
-alias0 = PrePass0
+filter_linear2 = "true"
+scale_type2 = "viewport"
 
-shader1 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass1.slang
-alias1 = NPass1
-scale_type_x1 = source
-scale_type_y1 = source
-scale_x1 = 4.0
-scale_y1 = 1.0
-float_framebuffer1 = true
-filter_linear1 = false
-
-shader2 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass2.slang
-filter_linear2 = true
-float_framebuffer2 = true
-scale_type2 = source
-scale_x2 = 0.5
-scale_y2 = 1.0
-
-shader3 = ../../crt/shaders/guest/advanced/ntsc/ntsc-pass3.slang
-filter_linear3 = true
-scale_type3 = source
-scale_x3 = 1.0
-scale_y3 = 1.0
-
-shader4 = ../../crt/shaders/fakelottes.slang
-filter_linear4 = true
-scale_type4 = viewport
-
-cust_artifacting = "0.000000"
-cust_fringing = "0.000000"
+u_svideo = "1.000000"


### PR DESCRIPTION
This updates https://github.com/libretro/slang-shaders/pull/715, as commented in https://github.com/libretro/slang-shaders/pull/754#issuecomment-3412970674, as it seems to run faster than the previously used NTSC shader passes.

<img width="1920" height="1080" alt="Screenshot From 2025-10-16 23-16-49" src="https://github.com/user-attachments/assets/b6b1c48a-a030-47c0-8907-c912652e583c" />
<img width="1920" height="1080" alt="Screenshot From 2025-10-16 23-18-08" src="https://github.com/user-attachments/assets/cb27e352-f25a-4c1c-9e51-d1a9f469e0b7" />