### PR TITLE
Fix for duplicate gamma in fakelottes-ntsc-composite and fakelottes-ntsc-svideo

### DIFF
--- a/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
@@ -1,7 +1,6 @@
-shaders = "3"
-shader0 = "../../crt/shaders/crt-consumer/linear.slang"
-shader1 = "../../crt/shaders/crt-consumer/ntsc_module.slang"
-shader2 = "../../crt/shaders/fakelottes.slang"
+shaders = "2"
+shader0 = "../../crt/shaders/crt-consumer/ntsc_module.slang"
+shader1 = "../../crt/shaders/fakelottes.slang"
 
-filter_linear2 = "true"
-scale_type2 = "viewport"
+filter_linear1 = "true"
+scale_type1 = "viewport"

--- a/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
@@ -1,9 +1,8 @@
-shaders = "3"
-shader0 = "../../crt/shaders/crt-consumer/linear.slang"
-shader1 = "../../crt/shaders/crt-consumer/ntsc_module.slang"
-shader2 = "../../crt/shaders/fakelottes.slang"
+shaders = "2"
+shader0 = "../../crt/shaders/crt-consumer/ntsc_module.slang"
+shader1 = "../../crt/shaders/fakelottes.slang"
 
-filter_linear2 = "true"
-scale_type2 = "viewport"
+filter_linear1 = "true"
+scale_type1 = "viewport"
 
 u_svideo = "1.000000"


### PR DESCRIPTION
Just a small update to #755, as commented in https://github.com/libretro/slang-shaders/pull/755#issuecomment-3415610643, which removes the duplicate gamma.