### PR TITLE
Fakelottes-NTSC: update parameters

### DIFF
--- a/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-composite.slangp
@@ -4,3 +4,5 @@ shader1 = "../../crt/shaders/fakelottes.slang"
 
 filter_linear1 = "true"
 scale_type1 = "viewport"
+
+u_chroma = "2.000000"

--- a/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
+++ b/presets/crt-plus-signal/fakelottes-ntsc-svideo.slangp
@@ -6,3 +6,5 @@ filter_linear1 = "true"
 scale_type1 = "viewport"
 
 u_svideo = "1.000000"
+
+u_chroma = "2.000000"


### PR DESCRIPTION
Just a small update to #756, this tweak a parameter to the ntsc_module shader, so that the colors match more closely the stock Fakelottes

<img width="1172" height="896" alt="Super Mario World-251116-221418" src="https://github.com/user-attachments/assets/b819dd54-5a6f-4bde-abb9-97d83871e493" />
<img width="1280" height="896" alt="Sonic The Hedgehog-251116-221905" src="https://github.com/user-attachments/assets/afd85d94-5fa8-48cb-bf86-7a9ce4183a62" />