### PR TITLE
Add pixel_transparency-simpletex_lcd preset

### DIFF
--- a/presets/pixel_transparency/pixel_transparency-simpletex_lcd.slangp
+++ b/presets/pixel_transparency/pixel_transparency-simpletex_lcd.slangp
@@ -1,0 +1,25 @@
+shaders = 2
+
+shader0 = ../../handheld/shaders/simpletex_lcd/simpletex_lcd.slang
+filter_linear0 = true
+wrap_mode0 = clamp_to_border
+mipmap_input0 = false
+float_framebuffer0 = false
+srgb_framebuffer0 = false
+scale_type0 = viewport
+
+shader1 = ../../handheld/shaders/pixel_transparency.slang
+filter_linear1 = false
+scale_type1 = viewport
+
+textures = "BACKGROUND"
+BACKGROUND = ../../handheld/shaders/simpletex_lcd/png/2k/textured_paper.png
+BACKGROUND_linear = false
+
+parameters = "GRID_INTENSITY;GRID_WIDTH;GRID_BIAS;DARKEN_GRID;DARKEN_COLOUR;BACKGROUND_INTENSITY"
+GRID_INTENSITY = "0.65"
+GRID_WIDTH = "0.65"
+GRID_BIAS = "0.6"
+DARKEN_GRID = "0.0"
+DARKEN_COLOUR = "0.05"
+BACKGROUND_INTENSITY = "0.0"


### PR DESCRIPTION
Combines simpletex_lcd with pixel_transparency shader for a nice light pixel grid.

<img width="800" height="720" alt="Pokemon Crystal-260116-172729" src="https://github.com/user-attachments/assets/8a747894-c1b1-49b2-a850-01bbfdad1d56" />
_simpletex alone_

<img width="800" height="720" alt="Pokemon Crystal-260116-172707" src="https://github.com/user-attachments/assets/7d93d098-52c9-4e21-b09b-6d94132cdf81" />
_simpletex with pixel_transparency_