### PR TITLE
V2.6.5 Sony Megatron Shader

### DIFF
--- a/hdr/shaders/crt-sony-megatron-source-pass-v2-config.slang
+++ b/hdr/shaders/crt-sony-megatron-source-pass-v2-config.slang
@@ -18,7 +18,8 @@ layout(push_constant) uniform Push
    float hcrt_saturation;
    float hcrt_gamma_in;
    float hcrt_gamma_cutoff;
-   float hcrt_colour_accurate;
+   float hcrt_expand_gamut;
+   float hcrt_colour_boost_factor;
 } params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
@@ -44,6 +45,6 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_SATURATION                     params.hcrt_saturation
 #define HCRT_GAMMA_IN                       params.hcrt_gamma_in
 #define HCRT_GAMMA_CUTOFF                   params.hcrt_gamma_cutoff
-#define HCRT_COLOUR_ACCURATE                params.hcrt_colour_accurate
+#define HCRT_COLOUR_BOOST_FACTOR            params.hcrt_colour_boost_factor
 
 #include "include/sdr_pass_v2.h"

--- a/hdr/shaders/crt-sony-megatron-source-pass-v2.slang
+++ b/hdr/shaders/crt-sony-megatron-source-pass-v2.slang
@@ -41,7 +41,7 @@ layout(push_constant) uniform Push
    float hcrt_saturation;
    float hcrt_gamma_in;
    float hcrt_gamma_cutoff;
-   float hcrt_colour_accurate;
+   float hcrt_colour_boost_factor;
 } params;
 
 layout(std140, set = 0, binding = 0) uniform UBO
@@ -67,7 +67,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_SATURATION                     params.hcrt_saturation
 #define HCRT_GAMMA_IN                       params.hcrt_gamma_in
 #define HCRT_GAMMA_CUTOFF                   params.hcrt_gamma_cutoff
-#define HCRT_COLOUR_ACCURATE                params.hcrt_colour_accurate
+#define HCRT_COLOUR_BOOST_FACTOR            params.hcrt_colour_boost_factor
 
 #define COMPAT_TEXTURE(c, d) texture(c, d)
 

--- a/hdr/shaders/crt-sony-megatron-v2-config.slang
+++ b/hdr/shaders/crt-sony-megatron-v2-config.slang
@@ -58,11 +58,11 @@ layout(std140, set = 0, binding = 0) uniform UBO
 	uint FrameCount;
 	float EnableHDR;
 	float PaperWhiteNits;
-	float ExpandGamut;
 	
 	float hcrt_r709_gamma_out;
 	float hcrt_srgb_gamma_out;
 	float hcrt_p3_gamma_out;
+   float hcrt_adobe_gamma_out;
 	float hcrt_r709_gamma_cutoff;
 	float hcrt_srgb_gamma_cutoff;
 	
@@ -77,10 +77,10 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_HDR                             global.EnableHDR
 #define HCRT_OUTPUT_COLOUR_SPACE             params.hcrt_colour_space
 #define HCRT_PAPER_WHITE_NITS                params.hcrt_paper_white_nits
-#define HCRT_EXPAND_GAMUT                    params.hcrt_expand_gamut
 #define HCRT_R709_GAMMA_OUT                  global.hcrt_r709_gamma_out
 #define HCRT_SRGB_GAMMA_OUT                  global.hcrt_srgb_gamma_out
 #define HCRT_P3_GAMMA_OUT                    global.hcrt_p3_gamma_out
+#define HCRT_ADOBE_GAMMA_OUT                 global.hcrt_adobe_gamma_out
 #define HCRT_R709_GAMMA_CUTOFF               global.hcrt_r709_gamma_cutoff
 #define HCRT_SRGB_GAMMA_CUTOFF               global.hcrt_srgb_gamma_cutoff
 #define HCRT_BLOOM_STRENGTH                  params.hcrt_bloom_strength

--- a/hdr/shaders/crt-sony-megatron-v2.slang
+++ b/hdr/shaders/crt-sony-megatron-v2.slang
@@ -55,11 +55,11 @@ layout(std140, set = 0, binding = 0) uniform UBO
 	uint FrameCount;
 	float EnableHDR;
 	float PaperWhiteNits;
-	float ExpandGamut;
 	
 	float hcrt_r709_gamma_out;
 	float hcrt_srgb_gamma_out;
 	float hcrt_p3_gamma_out;
+   float hcrt_adobe_gamma_out;
 	float hcrt_r709_gamma_cutoff;
 	float hcrt_srgb_gamma_cutoff;
 	
@@ -74,10 +74,10 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define HCRT_HDR                             global.EnableHDR
 #define HCRT_OUTPUT_COLOUR_SPACE             params.hcrt_colour_space
 #define HCRT_PAPER_WHITE_NITS                global.PaperWhiteNits
-#define HCRT_EXPAND_GAMUT                    global.ExpandGamut
 #define HCRT_R709_GAMMA_OUT                  global.hcrt_r709_gamma_out
 #define HCRT_SRGB_GAMMA_OUT                  global.hcrt_srgb_gamma_out
 #define HCRT_P3_GAMMA_OUT                    global.hcrt_p3_gamma_out
+#define HCRT_ADOBE_GAMMA_OUT                 global.hcrt_adobe_gamma_out
 #define HCRT_R709_GAMMA_CUTOFF               global.hcrt_r709_gamma_cutoff
 #define HCRT_SRGB_GAMMA_CUTOFF               global.hcrt_srgb_gamma_cutoff
 #define HCRT_BLOOM_STRENGTH                  params.hcrt_bloom_strength

--- a/hdr/shaders/include/gamma_correct.h
+++ b/hdr/shaders/include/gamma_correct.h
@@ -12,6 +12,25 @@ const mat3 kXYZ_to_DCIP3 = mat3 (
    -0.8294889696f,  1.7626640603f,  0.0236246858f,
     0.0358458302f, -0.0761723893f,  0.9568845240f);
 
+const mat3 k2020_to_sRGB = mat3(
+    1.660491f, -0.587641f, -0.072850f,
+   -0.124550f,  1.132900f, -0.008349f,
+   -0.018151f, -0.100579f,  1.118730f
+);
+
+const mat3 k2020_to_P3 = mat3(
+    1.343578f, -0.282180f, -0.061399f,
+   -0.065297f,  1.075788f, -0.010490f,
+    0.002822f, -0.019598f,  1.016777f
+);
+
+const mat3 k2020_to_Adobe = mat3(
+    1.151978f, -0.097503f, -0.054475f,
+   -0.124550f,  1.132900f, -0.008349f,
+   -0.022530f, -0.049807f,  1.072337f
+);
+
+
 float LinearTosRGB_1(const float channel)
 {
 	return (channel > (HCRT_SRGB_GAMMA_CUTOFF * (1.0f / 1000.0f))) ? (1.055f * pow(channel, 1.0f / HCRT_SRGB_GAMMA_OUT)) - 0.055f : channel * 12.92f; 
@@ -24,7 +43,7 @@ vec3 LinearTosRGB(const vec3 colour)
 
 float LinearTo709_1(const float channel)
 {
-	return (channel >= (HCRT_R709_GAMMA_CUTOFF * (1.0f / 1000.0f))) ? pow(channel * 1.099f, 1.0f / HCRT_R709_GAMMA_OUT) - 0.099f : channel * 4.5f;
+    return (channel >= (HCRT_R709_GAMMA_CUTOFF * (1.0f / 1000.0f))) ? (1.099f * pow(channel, 1.0f / HCRT_R709_GAMMA_OUT)) - 0.099f : channel * 4.5f;
 }
 
 vec3 LinearTo709(const vec3 colour)

--- a/hdr/shaders/include/parameters_v2.h
+++ b/hdr/shaders/include/parameters_v2.h
@@ -4,27 +4,30 @@
 #pragma parameter hcrt_user_settings                 "YOUR DISPLAY'S SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_lcd_resolution                "    Display's Resolution: 1080p | 4K | 8K"                    1.0      0.0   2.0      1.0
 #pragma parameter hcrt_lcd_subpixel                  "    Display's Subpixel Layout: RGB | RWBG (OLED) | BGR"       0.0      0.0   2.0      1.0
+#pragma parameter hcrt_colour_space                  "    Display's Colour Space: r709 | sRGB | DCI-P3 | Adobe"     1.0      0.0   3.0      1.0
+#pragma parameter hcrt_colour_boost_factor           "    Colour Boost"                                             1.0      0.0   5.0      0.01
 #pragma parameter hcrt_space2                        " "                                                            0.0      0.0   0.0001   0.0001
 
-#pragma parameter hcrt_sdr_mode_settings             "SDR MODE SETTINGS"                                            0.0      0.0   0.0001   0.0001   
-#pragma parameter hcrt_support8                      "    These settings only apply when HDR is turned off"       	0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_space4                        " "                                                            0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_colour_space                  "    Display's Colour Space: r709 | sRGB | DCI-P3"        		1.0      0.0   2.0      1.0
+#pragma parameter hcrt_sdr_mode_settings             "SDR MODE SETTINGS"                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_r709_gamma_out                "    r709 Gamma"                                          		2.22     1.0   5.0      0.01
 #pragma parameter hcrt_srgb_gamma_out                "    sRGB Gamma"                                          		2.4      1.0   5.0      0.01
 #pragma parameter hcrt_p3_gamma_out                  "    DCI-P3 Gamma"                                        		2.6      1.0   5.0      0.01
+#pragma parameter hcrt_adobe_gamma_out               "    Adobe Gamma"                                              2.2      1.0   5.0      0.01
 #pragma parameter hcrt_r709_gamma_cutoff             "    r709 Gamma Cutoff (x1000)"                           		1.0      0.0   100.0    1.00
 #pragma parameter hcrt_srgb_gamma_cutoff             "    sRGB Gamma Cutoff (x1000)"                           		1.0      0.0   100.0    1.00
+#pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0001
 
-#pragma parameter hcrt_space5                        " "                                                            0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_developer_settings            "CRT SETTINGS:"                                                0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_support3                      "    Default white points for the different colour systems:"   0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_support4                      "    709: D65, PAL: D65, NTSC-U: D65, NTSC-J: D93"         	0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_space6                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_crt_physicals                 "CRT SETTINGS:"                                                0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_crt_screen_type               "    Screen Type: APERTURE GRILLE | SHADOW MASK | SLOT MASK"   0.0      0.0   2.0      1.0
 #pragma parameter hcrt_crt_resolution                "    Resolution: 300TVL | 600TVL | 800TVL | 1000TVL"           1.0      0.0   3.0      1.0
 #pragma parameter hcrt_colour_system                 "    Colour System: r709 | PAL | NTSC-U | NTSC-J"              2.0      0.0   3.0      1.0
 #pragma parameter hcrt_phosphor_set                  "    Phosphors: NONE | P22-J | P22-80 | P22-90 | RPTV | 1953"  0.0      0.0   5.0      1.0
+#pragma parameter hcrt_space5                        " "                                                            0.0      0.0   0.0001   0.0001
+
+#pragma parameter hcrt_image_controls                "IMAGE ADJUSTMENT SETTINGS:"                                   0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support3                      "    Default white points for the different colour systems:"   0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support4                      "    709: D65, PAL: D65, NTSC-U: D65, NTSC-J: D93"         	0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space6                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_white_temperature_D65         "    D65 White Temperature (Kelvin)"                    		6504.0   0.0   18500.0  100.0
 #pragma parameter hcrt_white_temperature_D93         "    D93 White Temperature (Kelvin)"                    		9305.0   0.0   18500.0  100.0
 #pragma parameter hcrt_brightness                    "    Brightness"                                               0.0     -1.0   1.0      0.01
@@ -33,8 +36,9 @@
 #pragma parameter hcrt_gamma_in                      "    Gamma"                                                    2.22     1.0   5.0      0.01
 #pragma parameter hcrt_gamma_cutoff                  "    Inverse Gamma Cutoff (x1000)"                             1.0      0.0   100.0    1.0
 #pragma parameter hcrt_bloom_strength                "    Bloom Strength"                                           0.0      0.0   1.0      0.01
-
 #pragma parameter hcrt_space7                        " "                                                            0.0      0.0   0.0001   0.0001
+
+#pragma parameter hcrt_space8                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings0           "    VERTICAL SETTINGS:"                                       0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_v_size                        "        Vertical Size"                                        1.00     0.8   1.2      0.01
 #pragma parameter hcrt_v_cent                        "        Vertical Center"                                      0.00  -200.0 200.0      1.0
@@ -50,7 +54,7 @@
 #pragma parameter hcrt_blue_scanline_min             "        Blue Scanline Min"                                    0.50     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_max             "        Blue Scanline Max"                                    1.00     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_attack          "        Blue Scanline Attack"                                 0.20     0.0   1.0      0.01
-#pragma parameter hcrt_space8                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space9                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings1           "    HORIZONTAL SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_h_size                        "        Horizontal Size"                                      1.00     0.8   1.2      0.01
 #pragma parameter hcrt_h_cent                        "        Horizontal Center"                                    0.00  -200.0 200.0      1.0

--- a/hdr/shaders/include/parameters_v2_config.h
+++ b/hdr/shaders/include/parameters_v2_config.h
@@ -4,29 +4,35 @@
 #pragma parameter hcrt_user_settings                 "YOUR DISPLAY'S SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_lcd_resolution                "    Display's Resolution: 1080p | 4K | 8K"                    1.0      0.0   2.0      1.0
 #pragma parameter hcrt_lcd_subpixel                  "    Display's Subpixel Layout: RGB | RWBG (OLED) | BGR"       0.0      0.0   2.0      1.0
-#pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_hdr_mode_settings             "    HDR MODE SETTINGS"                                        0.0      0.0   0.0001   0.0001   
-#pragma parameter hcrt_max_nits                      "        Display's Peak Luminance"                             1000.0   0.0   10000.0  10.0
-#pragma parameter hcrt_paper_white_nits              "        Display's Paper White Luminance"                      200.0    0.0   10000.0  10.0
-#pragma parameter hcrt_expand_gamut                  "        Colour Boost"                                         0.0      0.0   1.0      1.0
-#pragma parameter hcrt_space4                        " "                                                            0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_sdr_mode_settings             "    SDR MODE SETTINGS"                                        0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_colour_space                  "        Display's Colour Space: r709 | sRGB | DCI-P3"        	1.0      0.0   2.0      1.0
-#pragma parameter hcrt_r709_gamma_out                "        r709 Gamma"                                          	2.22     1.0   5.0      0.01
-#pragma parameter hcrt_srgb_gamma_out                "        sRGB Gamma"                                          	2.4      1.0   5.0      0.01
-#pragma parameter hcrt_p3_gamma_out                  "        DCI-P3 Gamma"                                        	2.6      1.0   5.0      0.01
-#pragma parameter hcrt_r709_gamma_cutoff             "        r709 Gamma Cutoff (x1000)"                           	1.0      0.0   100.0    1.00
-#pragma parameter hcrt_srgb_gamma_cutoff             "        sRGB Gamma Cutoff (x1000)"                           	1.0      0.0   100.0    1.00
-#pragma parameter hcrt_space5                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_colour_space                  "    Display's Colour Space: r709 | sRGB | DCI-P3 | Adobe"     1.0      0.0   3.0      1.0
+#pragma parameter hcrt_colour_boost_factor           "    Colour Boost"                                             1.0      0.0   5.0      0.01
+#pragma parameter hcrt_space2                        " "                                                            0.0      0.0   0.0001   0.0001
 
-#pragma parameter hcrt_developer_settings            "CRT SETTINGS:"                                                0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_support3                      "    Default white points for the different colour systems:"   0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_support4                      "    709: D65, PAL: D65, NTSC-U: D65, NTSC-J: D93"         	0.0      0.0   0.0001   0.0001
-#pragma parameter hcrt_space6                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_hdr_mode_settings             "HDR MODE SETTINGS"                                            0.0      0.0   0.0001   0.0001   
+#pragma parameter hcrt_max_nits                      "    Display's Peak Luminance"                                 1000.0   0.0   10000.0  10.0
+#pragma parameter hcrt_paper_white_nits              "    Display's Paper White Luminance"                          200.0    0.0   10000.0  10.0
+#pragma parameter hcrt_space3                        " "                                                            0.0      0.0   0.0001   0.0001
+
+#pragma parameter hcrt_sdr_mode_settings             "SDR MODE SETTINGS"                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_r709_gamma_out                "    r709 Gamma"                                          		2.22     1.0   5.0      0.01
+#pragma parameter hcrt_srgb_gamma_out                "    sRGB Gamma"                                          		2.4      1.0   5.0      0.01
+#pragma parameter hcrt_p3_gamma_out                  "    DCI-P3 Gamma"                                        		2.6      1.0   5.0      0.01
+#pragma parameter hcrt_adobe_gamma_out               "    Adobe Gamma"                                              2.2      1.0   5.0      0.01
+#pragma parameter hcrt_r709_gamma_cutoff             "    r709 Gamma Cutoff (x1000)"                           		1.0      0.0   100.0    1.00
+#pragma parameter hcrt_srgb_gamma_cutoff             "    sRGB Gamma Cutoff (x1000)"                           		1.0      0.0   100.0    1.00
+#pragma parameter hcrt_space4                        " "                                                            0.0      0.0   0.0001   0.0001
+
+#pragma parameter hcrt_crt_physicals                 "CRT SETTINGS:"                                                0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_crt_screen_type               "    Screen Type: APERTURE GRILLE | SHADOW MASK | SLOT MASK"   0.0      0.0   2.0      1.0
 #pragma parameter hcrt_crt_resolution                "    Resolution: 300TVL | 600TVL | 800TVL | 1000TVL"           1.0      0.0   3.0      1.0
 #pragma parameter hcrt_colour_system                 "    Colour System: r709 | PAL | NTSC-U | NTSC-J"              2.0      0.0   3.0      1.0
 #pragma parameter hcrt_phosphor_set                  "    Phosphors: NONE | P22-J | P22-80 | P22-90 | RPTV | 1953"  0.0      0.0   5.0      1.0
+#pragma parameter hcrt_space6                        " "                                                            0.0      0.0   0.0001   0.0001
+
+#pragma parameter hcrt_image_controls                "IMAGE ADJUSTMENT SETTINGS:"                                   0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support3                      "    Default white points for the different colour systems:"   0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_support4                      "    709: D65, PAL: D65, NTSC-U: D65, NTSC-J: D93"         	0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space7                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_white_temperature_D65         "    D65 White Temperature (Kelvin)"                    		6504.0   0.0   18500.0  100.0
 #pragma parameter hcrt_white_temperature_D93         "    D93 White Temperature (Kelvin)"                    		9305.0   0.0   18500.0  100.0
 #pragma parameter hcrt_brightness                    "    Brightness"                                               0.0     -1.0   1.0      0.01
@@ -35,7 +41,7 @@
 #pragma parameter hcrt_gamma_in                      "    Gamma"                                                    2.22     1.0   5.0      0.01
 #pragma parameter hcrt_gamma_cutoff                  "    Inverse Gamma Cutoff (x1000)"                             1.0      0.0   100.0    1.0
 #pragma parameter hcrt_bloom_strength                "    Bloom Strength"                                           0.0      0.0   1.0      0.01
-#pragma parameter hcrt_space7                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space8                        " "                                                            0.0      0.0   0.0001   0.0001
 
 #pragma parameter hcrt_developer_settings0           "    VERTICAL SETTINGS:"                                       0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_v_size                        "        Vertical Size"                                        1.00     0.8   1.2      0.01
@@ -52,7 +58,7 @@
 #pragma parameter hcrt_blue_scanline_min             "        Blue Scanline Min"                                    0.50     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_max             "        Blue Scanline Max"                                    1.00     0.0   2.0      0.01 
 #pragma parameter hcrt_blue_scanline_attack          "        Blue Scanline Attack"                                 0.20     0.0   1.0      0.01
-#pragma parameter hcrt_space8                        " "                                                            0.0      0.0   0.0001   0.0001
+#pragma parameter hcrt_space9                        " "                                                            0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_developer_settings1           "    HORIZONTAL SETTINGS:"                                     0.0      0.0   0.0001   0.0001
 #pragma parameter hcrt_h_size                        "        Horizontal Size"                                      1.00     0.8   1.2      0.01
 #pragma parameter hcrt_h_cent                        "        Horizontal Center"                                    0.00  -200.0 200.0      1.0


### PR DESCRIPTION
## Summary
- Rework colour pipeline to use Rec.2020 as intermediate colour space for improved colour accuracy
- Add Adobe RGB as fourth output colour space option (alongside r709, sRGB, DCI-P3)
- Replace ExpandGamut/colour_accurate with continuous colour boost control
- Add Rec.2020 conversion matrices for sRGB, DCI-P3, and Adobe RGB output targets
- Add V2-specific colour grading path with Rec.2020 luma-based saturation
- Rework output stage with per-colour-space SDR and HDR conversion paths
- Fix Rec.709 gamma formula operator precedence
- Reorganize UI parameter layout for clearer grouping