### PR TITLE
vectorscale: fix junction artifacts + exact cubic closest-point solver

### DIFF
--- a/edge-smoothing/vectorscale/shaders/cell-graph.slang
+++ b/edge-smoothing/vectorscale/shaders/cell-graph.slang
@@ -276,22 +276,30 @@ void compute_corner(int cx, int cy, out CPData slot0, out CPData slot1) {
     bool is_interior = cx > 0 && cy > 0 && cx < IMG_W() && cy < IMG_H();
 
     if (!is_interior) {
+        // Border CPs: pinned, connected back to interior neighbor via
+        // nbr_cp_idx (graph-only, no race). from_dir = direction at
+        // the border corner (not the interior corner).
         bool has_boundary = false;
-        if (cy == 0 && cx > 0 && cx < IMG_W()) {
+        if (cy == 0 && cx > 0 && cx < IMG_W())
             has_boundary = !similar(cx - 1, 0, cx, 0);
-        }
-        if (cy == IMG_H() && cx > 0 && cx < IMG_W()) {
+        if (cy == IMG_H() && cx > 0 && cx < IMG_W())
             has_boundary = has_boundary || !similar(cx - 1, IMG_H() - 1, cx, IMG_H() - 1);
-        }
-        if (cx == 0 && cy > 0 && cy < IMG_H()) {
+        if (cx == 0 && cy > 0 && cy < IMG_H())
             has_boundary = has_boundary || !similar(0, cy - 1, 0, cy);
-        }
-        if (cx == IMG_W() && cy > 0 && cy < IMG_H()) {
+        if (cx == IMG_W() && cy > 0 && cy < IMG_H())
             has_boundary = has_boundary || !similar(IMG_W() - 1, cy - 1, IMG_W() - 1, cy);
-        }
         if (has_boundary) {
+            int nbr = -1;
+            int our_dir = -1;
+            if (cy == IMG_H())      { nbr = nbr_cp_idx(cx, cy-1, 0); our_dir = 0; }
+            else if (cy == 0)       { nbr = nbr_cp_idx(cx, cy+1, 2); our_dir = 2; }
+            else if (cx == IMG_W()) { nbr = nbr_cp_idx(cx-1, cy, 3); our_dir = 3; }
+            else if (cx == 0)       { nbr = nbr_cp_idx(cx+1, cy, 1); our_dir = 1; }
+
             slot0.pos = vec2(float(cx), float(cy));
-            slot0.flag = 1u; // pinned border CP
+            slot0.flag = 1u;
+            slot0.next = nbr;
+            slot0.next_dir = our_dir;
         }
         return;
     }

--- a/edge-smoothing/vectorscale/shaders/cell-rasterizer.slang
+++ b/edge-smoothing/vectorscale/shaders/cell-rasterizer.slang
@@ -176,31 +176,78 @@ vec2 beval_deriv(vec2 p0, vec2 p1, vec2 p2, float t) {
     return (t - 1.0) * p0 + (1.0 - 2.0 * t) * p1 + t * p2;
 }
 
-// ---- Closest point on B-spline span ----
+// ---- Closest point on B-spline span (exact cubic solver) ----
+//
+// D(t) = |B(t)-pt|² is degree 4, D'(t) is cubic → closed-form roots.
+// Evaluates D at all real roots in [0,1] + endpoints, returns global min.
 
 vec2 closest_on_span(vec2 p0, vec2 p1, vec2 p2, vec2 pt) {
-    float best_d2 = 1e10;
-    float best_t = 0.0;
-    for (int s = 0; s <= 4; s++) {
-        float t = float(s) * 0.25;
-        vec2 bp = beval(p0, p1, p2, t);
-        float d2 = dot(pt - bp, pt - bp);
-        if (d2 < best_d2) { best_d2 = d2; best_t = t; }
+    // Polynomial form: B(t) = a*t² + b*t + c
+    vec2 a = 0.5 * (p0 - 2.0 * p1 + p2);
+    vec2 b = p1 - p0;
+    vec2 e = 0.5 * (p0 + p1) - pt;  // c - pt
+
+    // D'(t)/2 cubic coefficients
+    float c3 = 2.0 * dot(a, a);
+    float c2 = 3.0 * dot(a, b);
+    float c1 = 2.0 * dot(a, e) + dot(b, b);
+    float c0 = dot(b, e);
+
+    #define EVAL_D2(t) dot((a*(t)+b)*(t)+e, (a*(t)+b)*(t)+e)
+
+    // Start with endpoints
+    float d0 = EVAL_D2(0.0);
+    float d1 = EVAL_D2(1.0);
+    float best_d2 = d0; float best_t = 0.0;
+    if (d1 < best_d2) { best_d2 = d1; best_t = 1.0; }
+
+    if (abs(c3) < 1e-12) {
+        // Degenerate: quadratic or linear
+        if (abs(c2) > 1e-12) {
+            float disc = c1*c1 - 4.0*c2*c0;
+            if (disc >= 0.0) {
+                float sq = sqrt(disc);
+                float inv = 0.5 / c2;
+                float t1 = (-c1 + sq) * inv;
+                float t2 = (-c1 - sq) * inv;
+                if (t1 > 0.0 && t1 < 1.0) { float dd = EVAL_D2(t1); if (dd < best_d2) { best_d2 = dd; best_t = t1; } }
+                if (t2 > 0.0 && t2 < 1.0) { float dd = EVAL_D2(t2); if (dd < best_d2) { best_d2 = dd; best_t = t2; } }
+            }
+        } else if (abs(c1) > 1e-12) {
+            float t1 = -c0 / c1;
+            if (t1 > 0.0 && t1 < 1.0) { float dd = EVAL_D2(t1); if (dd < best_d2) { best_d2 = dd; best_t = t1; } }
+        }
+    } else {
+        // Full cubic: depressed form via t = u - c2/(3·c3)
+        float inv3a = 1.0 / (3.0 * c3);
+        float shift = -c2 * inv3a;
+        float p = (3.0*c3*c1 - c2*c2) / (3.0*c3*c3);
+        float q = (2.0*c2*c2*c2 - 9.0*c3*c2*c1 + 27.0*c3*c3*c0) / (27.0*c3*c3*c3);
+        float disc = q*q/4.0 + p*p*p/27.0;
+
+        if (disc > 1e-12) {
+            // One real root
+            float sq = sqrt(disc);
+            float hq = -q * 0.5;
+            float u1 = sign(hq+sq) * pow(abs(hq+sq), 1.0/3.0);
+            float u2 = sign(hq-sq) * pow(abs(hq-sq), 1.0/3.0);
+            float t1 = u1 + u2 + shift;
+            if (t1 > 0.0 && t1 < 1.0) { float dd = EVAL_D2(t1); if (dd < best_d2) { best_d2 = dd; best_t = t1; } }
+        } else {
+            // Three real roots (trigonometric)
+            float r = sqrt(max(-p*p*p/27.0, 0.0));
+            float phi = (r < 1e-15) ? 0.0 : acos(clamp(-q/(2.0*r), -1.0, 1.0));
+            float cube_r = 2.0 * sign(r) * pow(abs(r), 1.0/3.0);
+            const float TAU = 6.283185307;
+            for (int k = 0; k < 3; k++) {
+                float angle = (phi + TAU * float(k)) / 3.0;
+                float t1 = cube_r * cos(angle) + shift;
+                if (t1 > 0.0 && t1 < 1.0) { float dd = EVAL_D2(t1); if (dd < best_d2) { best_d2 = dd; best_t = t1; } }
+            }
+        }
     }
 
-    vec2 b2 = p0 - 2.0 * p1 + p2;
-    for (int i = 0; i < 4; i++) {
-        vec2 bt = beval(p0, p1, p2, best_t);
-        vec2 bt1 = beval_deriv(p0, p1, p2, best_t);
-        vec2 diff = bt - pt;
-        float f = dot(bt1, diff);
-        float g = dot(b2, diff) + dot(bt1, bt1);
-        if (abs(g) > 1e-10)
-            best_t = clamp(best_t - f / g, 0.0, 1.0);
-    }
-
-    vec2 bp = beval(p0, p1, p2, best_t);
-    best_d2 = dot(pt - bp, pt - bp);
+    #undef EVAL_D2
     return vec2(best_t, best_d2);
 }
 

--- a/edge-smoothing/vectorscale/shaders/optimize-energy.slang
+++ b/edge-smoothing/vectorscale/shaders/optimize-energy.slang
@@ -166,11 +166,16 @@ void main() {
         return;
     }
 
-    // Skip nodes adjacent to crossings.
-    if ((read_flags(prev_idx) & IS_CROSSING) != 0u ||
-        (read_flags(next_idx) & IS_CROSSING) != 0u) {
-        FragColor = vec4(p.x, p.y, 0.0, 0.0);
-        return;
+    // Skip non-crossing nodes adjacent to crossings (crossing position
+    // depends on all 4 neighbors; optimizing one side without the other
+    // would break symmetry). Crossing nodes themselves must not be
+    // skipped — they handle their own combined-curvature optimization.
+    if ((flags & IS_CROSSING) == 0u) {
+        if ((read_flags(prev_idx) & IS_CROSSING) != 0u ||
+            (read_flags(next_idx) & IS_CROSSING) != 0u) {
+            FragColor = vec4(p.x, p.y, 0.0, 0.0);
+            return;
+        }
     }
 
     vec2 n0 = read_neighbor_pos(prev_idx);

--- a/edge-smoothing/vectorscale/shaders/update-tjunction.slang
+++ b/edge-smoothing/vectorscale/shaders/update-tjunction.slang
@@ -1,20 +1,21 @@
 #version 450
 #pragma format R32G32B32A32_SFLOAT
 
-// Pass: Post-optimization T-junction position correction.
+// Pass: Post-optimization junction position correction.
 //
-// Reads absolute positions from Source, applies T-junction correction,
-// stores corrected absolute positions.
+// Crossings: inverse B-spline correction (each slot independently)
+// T-junctions: forward B-spline correction + stem snapping
 //
-// For each CP with IS_TJUNCTION flag, recompute position as:
-//   pos = 0.125 * prev_pos + 0.75 * pos + 0.125 * next_pos
-//
-// Also updates the stem CP at the other slot (i ^ 1) so it terminates
-// exactly on the smooth curve.
+// Uses Opt2 (original optimizer output) for the center weight,
+// Source (previous pass) for neighbor positions. This allows
+// multi-pass iteration: dispatch this shader 3 times, each reading
+// the previous pass's corrected positions as neighbors while using
+// the fixed original center positions.
 //
 // Input textures:
-//   Source (previous pass): optimized absolute positions
-//   CellGraph: original positions + neighbors + flags
+//   Source (previous pass): current positions (neighbors)
+//   Opt2: original optimizer output (center weight)
+//   CellGraph: neighbors + flags
 //
 // Output: (R=pos.x, G=pos.y, B=0, A=0)
 
@@ -28,6 +29,7 @@ layout(push_constant) uniform Push {
 layout(std140, set = 0, binding = 0) uniform UBO {
     mat4 MVP;
     vec4 CellGraphSize;
+    vec4 Opt2Size;
 } global;
 
 #pragma stage vertex
@@ -44,8 +46,9 @@ void main() {
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 FragColor;
 
-layout(set = 0, binding = 2) uniform sampler2D Source;    // optimized positions
+layout(set = 0, binding = 2) uniform sampler2D Source;    // current positions (neighbors)
 layout(set = 0, binding = 3) uniform sampler2D CellGraph; // pass 3 (neighbors + flags)
+layout(set = 0, binding = 4) uniform sampler2D Opt2;      // original optimizer output
 
 int IMG_W()    { return int(params.OriginalSize.x); }
 int IMG_H()    { return int(params.OriginalSize.y); }
@@ -69,6 +72,14 @@ vec2 read_pos(int cp_idx) {
     int cx, cy_slot;
     decode_cp(cp_idx, cx, cy_slot);
     vec4 val = texelFetch(Source, ivec2(cx, cy_slot), 0);
+    return vec2(val.r, val.g);
+}
+
+vec2 read_orig_pos(int cp_idx) {
+    if (cp_idx < 0 || cp_idx >= NUM_CPS()) return vec2(0.0);
+    int cx, cy_slot;
+    decode_cp(cp_idx, cx, cy_slot);
+    vec4 val = texelFetch(Opt2, ivec2(cx, cy_slot), 0);
     return vec2(val.r, val.g);
 }
 
@@ -113,14 +124,17 @@ void main() {
     int cp_slot = cy_slot % 2;
     int i = (cy * CORNERS_W() + col) * 2 + cp_slot;
 
-    vec2 curr_pos = read_pos(i);
     uint flags = read_flags(i);
+    vec2 curr_pos = read_pos(i);
+    vec2 orig_pos = read_orig_pos(i);
 
     int partner = i ^ 1;
     uint partner_flags = read_flags(partner);
 
-    // Valence-4 crossing: inverse B-spline correction so the curve
-    // passes through the grid corner (current position) at t=0.5.
+    // Valence-4 crossing: inverse B-spline correction.
+    // Both slots processed independently (different pp/np require
+    // different corrected positions for both curves to pass through
+    // the same grid_pos at t=0.5).
     if ((flags & IS_CROSSING) != 0u) {
         ivec2 nbrs = read_neighbors(i);
         int prev_idx = nbrs.x;
@@ -129,7 +143,7 @@ void main() {
         if (prev_idx >= 0 && next_idx >= 0) {
             vec2 prev_pos = read_pos(prev_idx);
             vec2 next_pos = read_pos(next_idx);
-            vec2 corrected = (curr_pos - 0.125 * prev_pos - 0.125 * next_pos) / 0.75;
+            vec2 corrected = (orig_pos - 0.125 * prev_pos - 0.125 * next_pos) / 0.75;
             FragColor = vec4(corrected.x, corrected.y, 0.0, 0.0);
             return;
         }
@@ -141,11 +155,12 @@ void main() {
         if (prev_idx >= 0 && next_idx >= 0) {
             vec2 prev_pos = read_pos(prev_idx);
             vec2 next_pos = read_pos(next_idx);
-            vec2 corrected = 0.125 * prev_pos + 0.75 * curr_pos + 0.125 * next_pos;
+            vec2 corrected = 0.125 * prev_pos + 0.75 * orig_pos + 0.125 * next_pos;
             FragColor = vec4(corrected.x, corrected.y, 0.0, 0.0);
             return;
         }
     } else if ((partner_flags & IS_TJUNCTION) != 0u && flags == 1u) {
+        // Stem: snap onto through curve
         ivec2 partner_nbrs = read_neighbors(partner);
         int prev_idx = partner_nbrs.x;
         int next_idx = partner_nbrs.y;

--- a/edge-smoothing/vectorscale/vectorscale.slangp
+++ b/edge-smoothing/vectorscale/vectorscale.slangp
@@ -3,7 +3,7 @@
 # Intermediate textures are over-allocated using source-relative scales:
 #   Cell graph: 2W x 7H (needs (W+1) x 6(H+1), works for H >= 6)
 #   Positions:  2W x 3.5H (needs (W+1) x 2(H+1), works for H >= 2)
-shaders = 8
+shaders = 10
 
 shader0 = shaders/similarity-graph.slang
 alias0 = SimilarityGraph
@@ -57,17 +57,36 @@ scale5 = 1.0
 wrap_mode5 = clamp_to_border
 float_framebuffer5 = true
 
+# T-junction/crossing correction: 3 iterations for convergence.
+# Each pass reads neighbor positions from Source (previous pass) and
+# original center positions from Opt2.
 shader6 = shaders/update-tjunction.slang
-alias6 = FinalPositions
+alias6 = TJunc1
 filter_linear6 = false
 scale_type6 = source
 scale6 = 1.0
 wrap_mode6 = clamp_to_border
 float_framebuffer6 = true
 
-shader7 = shaders/cell-rasterizer.slang
-alias7 = FinalOutput
-filter_linear7 = true
-scale_type7 = viewport
+shader7 = shaders/update-tjunction.slang
+alias7 = TJunc2
+filter_linear7 = false
+scale_type7 = source
 scale7 = 1.0
 wrap_mode7 = clamp_to_border
+float_framebuffer7 = true
+
+shader8 = shaders/update-tjunction.slang
+alias8 = FinalPositions
+filter_linear8 = false
+scale_type8 = source
+scale8 = 1.0
+wrap_mode8 = clamp_to_border
+float_framebuffer8 = true
+
+shader9 = shaders/cell-rasterizer.slang
+alias9 = FinalOutput
+filter_linear9 = true
+scale_type9 = viewport
+scale9 = 1.0
+wrap_mode9 = clamp_to_border


### PR DESCRIPTION
## Summary

- **Fix crossing artifacts**: both crossing CP slots are now corrected independently (different chain neighbors require different inverse B-spline corrections for both curves to pass through the same grid point)
- **Fix T-junction artifacts**: iterative solver with saved original positions ensures stems land exactly on the through curve when neighbors are themselves junction CPs
- **Fix adjacent crossing skip**: crossings at neighboring grid corners no longer block each other from being optimized
- **Exact cubic closest-point solver**: replaces Newton-Raphson + coarse sweep with analytical cubic root solve, eliminating degenerate endpoint traps and finding the true global minimum
- **Fix border CP connectivity**: border CPs now connect back to their interior neighbors, producing proper B-spline edges at the image border instead of leaving gaps at the edges

## Visual impact

The junction fixes resolve minor artifacts visible at high scale factors (32x+) where small triangular slivers of the wrong color appear at junction points where three or four color regions meet. The border CP fix is mostly imperceptible because the nearest-curve rasterizer's fallback pixel lookup masks the edge gaps — but it is the correct fix and matters for alternative rasterizers.

## Performance

Measured performance is identical before and after on GPU — the rasterizer is not the bottleneck. The exact cubic solver should be slightly faster than the Newton approach on most GPUs (fixed arithmetic vs iterative loop with branches), though the impact is largely negligible. On the upstream CPU rasterizer ([vibeboy@ecc9a2c](https://github.com/northbymidwest/vibeboy/commit/ecc9a2cb6629fd076ca406bc6ce9e1288aa52eef)) the cubic solver is ~2.2× faster.

## Details

The cubic solver analytically solves D'(t)=0 for the degree-4 distance function via the depressed cubic (Cardano/trigonometric method). No iterative convergence, no coarse sweep, no degenerate endpoint traps — just exact roots + endpoint evaluation.

The preset now runs \`update-tjunction\` 3 times (was 1) for iterative convergence when junction CPs are neighbors of other junction CPs. Each pass reads original positions from \`Opt2\` for the center weight.

Border CPs use \`nbr_cp_idx\` to find their interior neighbor and set the reciprocal connection.

---

Sorry for the quick follow-up to #894 — the junction alignment is now actually correct and should eliminate the artifacts entirely (up to the convergence of the update-tjunction iterations).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)