### PR TITLE
add a note to a parameter

### DIFF
--- a/subframe-bfi/shaders/adaptive_strobe-koko.slang
+++ b/subframe-bfi/shaders/adaptive_strobe-koko.slang
@@ -21,7 +21,7 @@ layout(push_constant) uniform Push {
 #pragma parameter _ADPT_STROBE_GAIN_ADJ_NODARK   "          Less gain on dark colors"    1.0   0.0  1.0  0.05
 #pragma parameter _ADPT_STROBE_GAMMA_ADJ         "   .   Post Gamma adjustment"   0.9   0.5  4.0  0.05
 #pragma parameter _ADPT_LCD_RETENTION_FIX        "   .   LCD Retention workaround cadence (frames)"    3600  0.0  300000.0  50.0
-#pragma parameter _ADPT_STROBE_ADAPTIVE          "   .   Only apply to moving areas"                   0.0   0.0  1.0       1.0
+#pragma parameter _ADPT_STROBE_ADAPTIVE          "   .   Only apply to moving areas (120hz max)"                   0.0   0.0  1.0       1.0
 #pragma parameter _ADPT_DEBUG_ONOFF              "   .   Debug: Flip effect ON/OFF every (frames)"     0.0   0.0  100000.0  10.0
 
 


### PR DESCRIPTION
Add a note to a parameter which is supported up to 120hz.
It really does not make sense to go higher, too much complex and with no real gains, as at 180hz the flickering is invisible anyway.
shader works fine as is till 120hz.