### PR TITLE
Adding EWA Cubics shader and updating SharpSmooth & Arcade with it

### DIFF
--- a/crt/crt-CreativeForce-Arcade.slangp
+++ b/crt/crt-CreativeForce-Arcade.slangp
@@ -1,14 +1,16 @@
 shaders = 2
 
-shader0 = ../interpolation/shaders/lanczos16-AR.slang
+shader0 = "../interpolation/shaders/EWA-Cubics.slang"
 filter_linear0 = false
 scale_type0    = viewport
+scale0         = 1.0
 wrap_mode0     = clamp_to_border
 
-shader1 = shaders/CreativeForce/crt-CreativeForce-Arcade.slang
+shader1 = "shaders/CreativeForce/crt-CreativeForce-Arcade.slang"
 filter_linear1 = false
 scale_type1    = viewport
+scale1         = 1.0
 wrap_mode1     = clamp_to_border
-# Override AR strength for this preset only
-parameters = AR_STRENGTH
-AR_STRENGTH = 0.29
+
+parameters = CubicMode
+CubicMode = 0.00

--- a/crt/crt-CreativeForce-SharpSmooth.slangp
+++ b/crt/crt-CreativeForce-SharpSmooth.slangp
@@ -1,14 +1,16 @@
 shaders = 2
 
-shader0 = ../interpolation/shaders/lanczos16-AR.slang
+shader0 = "../interpolation/shaders/EWA-Cubics.slang"
 filter_linear0 = false
 scale_type0    = viewport
+scale0         = 1.0
 wrap_mode0     = clamp_to_border
 
-shader1 = shaders/CreativeForce/crt-CreativeForce-SharpSmooth.slang
+shader1 = "shaders/CreativeForce/crt-CreativeForce-SharpSmooth.slang"
 filter_linear1 = false
 scale_type1    = viewport
+scale1         = 1.0
 wrap_mode1     = clamp_to_border
-# Override AR strength for this preset only
-parameters = AR_STRENGTH
-AR_STRENGTH = 0.29
+
+parameters = CubicMode
+CubicMode = 2.00

--- a/crt/shaders/CreativeForce/crt-CreativeForce-Arcade.slang
+++ b/crt/shaders/CreativeForce/crt-CreativeForce-Arcade.slang
@@ -1,7 +1,8 @@
 #version 450
 
 /*
-Author: djayjp aka CreativeForce (2025)
+Author: djayjp aka CreativeForce (2026)
+Modified: sharpening removed; gamma controls replaced by GBA Mode Gamma toggle.
 
 This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -18,20 +19,16 @@ This program is free software; you can redistribute it and/or
    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
-#pragma parameter TARGET_GAMMA_SEL    "Target Gamma (0=2.20, 1=2.40)"          0.00 0.00 1.00 1.00
-#pragma parameter MONITOR_GAMMA       "Monitor Gamma (normally left at 2.20)"  2.20 1.80 2.60 0.05
+// Gamma mode: 0 = default 2.20 source gamma, 1 = GBA-style 2.70 source gamma.
+#pragma parameter GBA_MODE_GAMMA     "GBA Mode Gamma"                       0.00 0.00 1.00 1.00
 
 // Vertical controls
-#pragma parameter V_BLACKS_PER        "Vertical Lines"  		       2.00 0.00 5.00 1.00
-#pragma parameter V_STRENGTH          "Vertical Lines Strength"                1.00 0.00 1.00 0.01
-#pragma parameter V_PHASE             "Vertical Phase"                         0.00 -256.00 256.00 1.00
-
-// Sharpen (post-linearize, pre-mask) — Radius fixed to 1px
-#pragma parameter SHARPEN_AMOUNT      "Sharpen Amount"                          0.00 0.00 1.00 0.01
-#pragma parameter SHARPEN_CLAMP       "Sharpen Clamp"                           0.10 0.00 0.50 0.01
+#pragma parameter V_BLACKS_PER       "Vertical Lines"                       2.00 0.00 5.00 1.00
+#pragma parameter V_STRENGTH         "Vertical Lines Strength"              1.00 0.00 1.00 0.01
+#pragma parameter V_PHASE            "Vertical Phase"                       0.00 -256.00 256.00 1.00
 
 // Auto-phase (placed last)
-#pragma parameter AUTO_PHASE          "Auto-Phase (lock to active content)"     1.00 0.00 1.00 1.00
+#pragma parameter AUTO_PHASE         "Auto-Phase (lock to active content)"   1.00 0.00 1.00 1.00
 
 layout(push_constant) uniform Push {
     vec4 SourceSize;
@@ -39,15 +36,11 @@ layout(push_constant) uniform Push {
     vec4 OutputSize;
     uint FrameCount;
 
-    float TARGET_GAMMA_SEL;
-    float MONITOR_GAMMA;
+    float GBA_MODE_GAMMA;
 
     float V_BLACKS_PER;
     float V_STRENGTH;
     float V_PHASE;
-
-    float SHARPEN_AMOUNT;
-    float SHARPEN_CLAMP;
 
     float AUTO_PHASE;
 } pc;
@@ -96,32 +89,12 @@ void main(){
     int v_period = v_blacks + 1;
     int v_thick  = v_blacks;
 
-    // Linear-light pipeline
-    float g_src = (pc.TARGET_GAMMA_SEL >= 0.5) ? 2.40 : 2.20;
-    float g_mon = clamp(pc.MONITOR_GAMMA, 1.0, 3.0);
+    // Fixed gamma pipeline.
+    // Default assumes source gamma 2.20. GBA Mode uses source gamma 2.70.
+    // Output is encoded for a fixed 2.20 monitor/output gamma.
+    float g_src = (pc.GBA_MODE_GAMMA >= 0.5) ? 2.70 : 2.20;
+    const float g_out = 2.20;
     vec3 col_lin = to_linear(col, g_src);
-
-    // === Sharpen (linear light), pre-mask; Radius fixed to 1 px (3x3) ===
-    float amount = clamp(pc.SHARPEN_AMOUNT, 0.0, 1.0);
-    if (amount > 0.0) {
-        vec2 texel = vec2(1.0) / max(pc.SourceSize.xy, vec2(1.0));
-        vec3 acc = vec3(0.0);
-        float cnt = 0.0;
-        for (int dy = -1; dy <= 1; ++dy) {
-            for (int dx = -1; dx <= 1; ++dx) {
-                vec3 s = to_linear(texture(Source, vTexCoord + texel * vec2(dx, dy)).rgb, g_src);
-                acc += s;
-                cnt += 1.0;
-            }
-        }
-        vec3 blur_lin = acc / max(cnt, 1.0);
-        vec3 high = col_lin - blur_lin;
-
-        float c = pc.SHARPEN_CLAMP;
-        high = clamp(high, vec3(-c), vec3(c));
-
-        col_lin = max(col_lin + amount * high, vec3(0.0));
-    }
 
     // Phase (integer-aligned)
     int v_phase_i = int(floor(pc.V_PHASE + 0.5));
@@ -148,6 +121,6 @@ void main(){
     // Apply mask
     vec3 masked_lin = col_lin * vec3(mask_val);
 
-    vec3 out_col = to_gamma(masked_lin, g_mon);
+    vec3 out_col = to_gamma(masked_lin, g_out);
     FragColor = vec4(out_col, 1.0);
 }

--- a/crt/shaders/CreativeForce/crt-CreativeForce-SharpSmooth.slang
+++ b/crt/shaders/CreativeForce/crt-CreativeForce-SharpSmooth.slang
@@ -1,7 +1,8 @@
 #version 450
 
 /*
-Author: djayjp aka CreativeForce (2025)
+Author: djayjp aka CreativeForce (2026)
+Modified: sharpening removed; gamma controls replaced by GBA Mode Gamma toggle.
 
 This program is free software; you can redistribute it and/or
    modify it under the terms of the GNU General Public License
@@ -18,20 +19,16 @@ This program is free software; you can redistribute it and/or
    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
-#pragma parameter TARGET_GAMMA_SEL    "Target Gamma (0=2.20, 1=2.40)"          0.00 0.00 1.00 1.00
-#pragma parameter MONITOR_GAMMA       "Monitor Gamma (normally left at 2.20)"  2.20 1.80 2.60 0.05
+// Gamma mode: 0 = default 2.20 source gamma, 1 = GBA-style 2.70 source gamma.
+#pragma parameter GBA_MODE_GAMMA     "GBA Mode Gamma"                       0.00 0.00 1.00 1.00
 
 // Vertical controls
-#pragma parameter V_BLACKS_PER        "Vertical Lines"  		       1.00 0.00 5.00 1.00
-#pragma parameter V_STRENGTH          "Vertical Lines Strength"                1.00 0.00 1.00 0.01
-#pragma parameter V_PHASE             "Vertical Phase"                         0.00 -256.00 256.00 1.00
-
-// Sharpen (post-linearize, pre-mask) — Radius fixed to 1px
-#pragma parameter SHARPEN_AMOUNT      "Sharpen Amount"                          0.00 0.00 1.00 0.01
-#pragma parameter SHARPEN_CLAMP       "Sharpen Clamp"                           0.10 0.00 0.50 0.01
+#pragma parameter V_BLACKS_PER       "Vertical Lines"                       1.00 0.00 5.00 1.00
+#pragma parameter V_STRENGTH         "Vertical Lines Strength"              1.00 0.00 1.00 0.01
+#pragma parameter V_PHASE            "Vertical Phase"                       0.00 -256.00 256.00 1.00
 
 // Auto-phase (placed last)
-#pragma parameter AUTO_PHASE          "Auto-Phase (lock to active content)"     1.00 0.00 1.00 1.00
+#pragma parameter AUTO_PHASE         "Auto-Phase (lock to active content)"   1.00 0.00 1.00 1.00
 
 layout(push_constant) uniform Push {
     vec4 SourceSize;
@@ -39,15 +36,11 @@ layout(push_constant) uniform Push {
     vec4 OutputSize;
     uint FrameCount;
 
-    float TARGET_GAMMA_SEL;
-    float MONITOR_GAMMA;
+    float GBA_MODE_GAMMA;
 
     float V_BLACKS_PER;
     float V_STRENGTH;
     float V_PHASE;
-
-    float SHARPEN_AMOUNT;
-    float SHARPEN_CLAMP;
 
     float AUTO_PHASE;
 } pc;
@@ -96,32 +89,12 @@ void main(){
     int v_period = v_blacks + 1;
     int v_thick  = v_blacks;
 
-    // Linear-light pipeline
-    float g_src = (pc.TARGET_GAMMA_SEL >= 0.5) ? 2.40 : 2.20;
-    float g_mon = clamp(pc.MONITOR_GAMMA, 1.0, 3.0);
+    // Fixed gamma pipeline.
+    // Default assumes source gamma 2.20. GBA Mode uses source gamma 2.70.
+    // Output is encoded for a fixed 2.20 monitor/output gamma.
+    float g_src = (pc.GBA_MODE_GAMMA >= 0.5) ? 2.70 : 2.20;
+    const float g_out = 2.20;
     vec3 col_lin = to_linear(col, g_src);
-
-    // === Sharpen (linear light), pre-mask; Radius fixed to 1 px (3x3) ===
-    float amount = clamp(pc.SHARPEN_AMOUNT, 0.0, 1.0);
-    if (amount > 0.0) {
-        vec2 texel = vec2(1.0) / max(pc.SourceSize.xy, vec2(1.0));
-        vec3 acc = vec3(0.0);
-        float cnt = 0.0;
-        for (int dy = -1; dy <= 1; ++dy) {
-            for (int dx = -1; dx <= 1; ++dx) {
-                vec3 s = to_linear(texture(Source, vTexCoord + texel * vec2(dx, dy)).rgb, g_src);
-                acc += s;
-                cnt += 1.0;
-            }
-        }
-        vec3 blur_lin = acc / max(cnt, 1.0);
-        vec3 high = col_lin - blur_lin;
-
-        float c = pc.SHARPEN_CLAMP;
-        high = clamp(high, vec3(-c), vec3(c));
-
-        col_lin = max(col_lin + amount * high, vec3(0.0));
-    }
 
     // Phase (integer-aligned)
     int v_phase_i = int(floor(pc.V_PHASE + 0.5));
@@ -148,6 +121,6 @@ void main(){
     // Apply mask
     vec3 masked_lin = col_lin * vec3(mask_val);
 
-    vec3 out_col = to_gamma(masked_lin, g_mon);
+    vec3 out_col = to_gamma(masked_lin, g_out);
     FragColor = vec4(out_col, 1.0);
 }

--- a/interpolation/EWA-Cubics.slangp
+++ b/interpolation/EWA-Cubics.slangp
@@ -1,0 +1,7 @@
+shaders = 1
+
+shader0 = "shaders/EWA-Cubics.slang"
+filter_linear0 = false
+scale_type0    = viewport
+scale0         = 1.0
+wrap_mode0     = clamp_to_border

--- a/interpolation/shaders/EWA-Cubics.slang
+++ b/interpolation/shaders/EWA-Cubics.slang
@@ -1,0 +1,136 @@
+#version 450
+/*
+  EWA / radial / cylindrical cubic family shader.
+
+  Cubic Family:
+    0 = Robidoux        (B = 0.3782, C = 0.3109)
+    1 = Mitchell        (B = 0.3333, C = 0.3333)
+    2 = Robidoux Sharp  (B = 0.2620, C = 0.3690)
+
+  Notes:
+    - Default is Robidoux.
+    - Uses the cubic Keys-family kernel radially (EWA/cylindrical style),
+      rather than separably.
+    - Support radius is 2.0.
+    - Compact 4x4 footprint, appropriate for radius-2 EWA cubic filtering.
+*/
+
+layout(push_constant) uniform Push {
+    vec4 SourceSize;
+    vec4 OriginalSize;
+    vec4 OutputSize;
+    uint FrameCount;
+    float CubicMode;
+} params;
+
+#pragma parameter CubicMode "Cubic (0=Robidoux/Smooth; 1=Mitchell/Medium; 2=RobidouxSharp)" 0.00 0.00 2.00 1.00
+
+layout(std140, set = 0, binding = 0) uniform UBO {
+    mat4 MVP;
+} global;
+
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+
+void main()
+{
+    gl_Position = global.MVP * Position;
+    vTexCoord = TexCoord;
+}
+
+#pragma stage fragment
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+const float SUPPORT = 2.0;
+
+void select_bc(float mode, out float B, out float C)
+{
+    if (mode < 0.5)
+    {
+        // Robidoux
+        B = 0.3782;
+        C = 0.3109;
+    }
+    else if (mode < 1.5)
+    {
+        // Mitchell: B = 1/3, C = 1/3, expressed to 4 decimal places.
+        B = 0.3333;
+        C = 0.3333;
+    }
+    else
+    {
+        // Robidoux Sharp
+        B = 0.2620;
+        C = 0.3690;
+    }
+}
+
+float cubic_bc_weight(float x, float B, float C)
+{
+    float ax = abs(x);
+    float ax2 = ax * ax;
+    float ax3 = ax2 * ax;
+
+    if (ax < 1.0)
+    {
+        return ((12.0 - 9.0 * B - 6.0 * C) * ax3
+              + (-18.0 + 12.0 * B + 6.0 * C) * ax2
+              + (6.0 - 2.0 * B)) / 6.0;
+    }
+    else if (ax < 2.0)
+    {
+        return ((-B - 6.0 * C) * ax3
+              + (6.0 * B + 30.0 * C) * ax2
+              + (-12.0 * B - 48.0 * C) * ax
+              + (8.0 * B + 24.0 * C)) / 6.0;
+    }
+
+    return 0.0;
+}
+
+vec3 sample_texel_center(vec2 center_px)
+{
+    return texture(Source, center_px * params.SourceSize.zw).rgb;
+}
+
+void main()
+{
+    float B, C;
+    select_bc(params.CubicMode, B, C);
+
+    vec2 pos = vTexCoord * params.SourceSize.xy;
+    vec2 c = floor(pos - vec2(0.5)) + vec2(0.5);
+
+    vec3 accum = vec3(0.0);
+    float wsum = 0.0;
+
+    // Radius-2 EWA cubic footprint.
+    for (int j = -1; j <= 2; ++j)
+    {
+        for (int i = -1; i <= 2; ++i)
+        {
+            vec2 sample_center = c + vec2(float(i), float(j));
+            vec2 delta = pos - sample_center;
+            float r = length(delta);
+
+            if (r >= SUPPORT)
+                continue;
+
+            float w = cubic_bc_weight(r, B, C);
+            if (w == 0.0)
+                continue;
+
+            accum += sample_texel_center(sample_center) * w;
+            wsum += w;
+        }
+    }
+
+    if (wsum > 0.0)
+        accum /= wsum;
+
+    FragColor = vec4(accum, 1.0);
+}

--- a/interpolation/shaders/EWA-Cubics.slang
+++ b/interpolation/shaders/EWA-Cubics.slang
@@ -1,5 +1,22 @@
 #version 450
 /*
+Author: djayjp aka CreativeForce (2026)
+
+This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+*/
+/*
   EWA / radial / cylindrical cubic family shader.
 
   Cubic Family:


### PR DESCRIPTION
You'll love this new EWA (elliptical weighted average)/radial/cylindrical/circular Cubic shader! It has 3 cubics in it selectable via a toggle (Robidoux/Mitchell/RobidouxSharp). Otherwise adding a "GBA Mode Gamma" toggle and removing the redundant sharpening filter of SharpSmooth & Arcade. 

Note: the EWA Cubics shader is technically not an "interpolation" filter, strictly-speaking, but it certainly is a reconstruction filter and functions very similarly to an interpolation filter (Robidoux preserves vertical and horizontal details in the no-op/unscaled condition). 