### PR TITLE
Yah: Refine scaling and mask options 

### DIFF
--- a/crt/shaders/crt-yah/common/subpixel-color.h
+++ b/crt/shaders/crt-yah/common/subpixel-color.h
@@ -5,6 +5,7 @@
 #include "constants.h"
 #include "geometry-helper.h"
 
+// colors
 const vec3 White = vec3(1.0, 1.0, 1.0);
 const vec3 Black = vec3(0.0, 0.0, 0.0);
 const vec3 Red = vec3(1.0, 0.0, 0.0);
@@ -13,6 +14,15 @@ const vec3 Green = vec3(0.0, 1.0, 0.0);
 const vec3 Magenta = vec3(1.0, 0.0, 1.0);
 const vec3 Yellow = vec3(1.0, 1.0, 0.0);
 const vec3 Cyan = vec3(0.0, 1.0, 1.0);
+
+// color combinations of three
+const vec3 ThreeC1[4] = vec3[4](Red,   Blue,  Red,   Green);
+const vec3 ThreeC2[4] = vec3[4](Green, Green, Blue,  Blue);
+const vec3 ThreeC3[4] = vec3[4](Blue,  Red,   Green, Red);
+
+// color combinations of two
+const vec3 TwoC1[4] = vec3[4](Green,   Magenta, Blue,   Yellow);
+const vec3 TwoC2[4] = vec3[4](Magenta, Green,   Yellow, Blue);
 
 // Returns an offset to shift the given pixel coordinate by x-amount for every second y-block.
 // @pixCoord - the pixel coordinate
@@ -85,10 +95,12 @@ vec3 get_subpixel_color(vec2 pixCoord, vec3 c1, vec3 c2, vec3 c3, vec3 c4)
 //   3: green, magenta, black
 //   4: red, green, blue
 //   5: red, green, blue, black
-// @color_swap - whether the sub-pixel colors shall be swapped
+// @color_order - determines the order of sub-pixel colors
 //   0: red/green/blue, green/magenta
-//   1: blue/green/red, blue/yellow
-vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_type, bool color_swap)
+//   1: blue/green/red, magenta/green
+//   2: red/blue/Green, blue/yellow
+//   3: green/blue/red, yellow/blue
+vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_type, int color_order)
 {
     vec3 color = White;
 
@@ -99,9 +111,9 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
 
     pixCoord /= size;
 
-    vec3 c1 = color_swap ? Blue : Red;
-    vec3 c2 = Green;
-    vec3 c3 = color_swap ? Red : Blue;
+    vec3 c1 = ThreeC1[color_order];
+    vec3 c2 = ThreeC2[color_order];
+    vec3 c3 = ThreeC3[color_order];
     vec3 c4 = Black;
 
     if (subpixel_type == 1)
@@ -111,13 +123,13 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     }
     else if (subpixel_type == 2)
     {
-        c1 = color_swap ? Yellow : Magenta;
-        c2 = color_swap ? Blue : Green;
+        c1 = TwoC1[color_order];
+        c2 = TwoC2[color_order];
     }
     else if (subpixel_type == 3)
     {
-        c1 = color_swap ? Yellow : Magenta;
-        c2 = color_swap ? Blue : Green;
+        c1 = TwoC1[color_order];
+        c2 = TwoC2[color_order];
         c3 = Black;
     }
 
@@ -248,12 +260,14 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
 //   3: green, magenta, black
 //   4: red, green, blue
 //   5: red, green, blue, black
-// @color_swap - whether the sub-pixel colors shall be swapped
+// @color_order - determines the order of sub-pixel colors
 //   0: red/green/blue, green/magenta
-//   1: blue/green/red, blue/yellow
+//   1: blue/green/red, magenta/green
+//   2: red/blue/Green, blue/yellow
+//   3: green/blue/red, yellow/blue
 // @radius - the corner radius of the sub-pixel
 // @smoothness - the smoothness of the sub-pixel
-vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_type, bool color_swap, float radius, float smoothness)
+vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_type, int color_order, float radius, float smoothness)
 {
     vec3 color = White;
 
@@ -267,9 +281,9 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     vec2 bounds = vec2(1.0, 1.0);
     vec2 scale = vec2(1.0, 1.0);
 
-    vec3 c1 = color_swap ? Blue : Red;
-    vec3 c2 = Green;
-    vec3 c3 = color_swap ? Red : Blue;
+    vec3 c1 = ThreeC1[color_order];
+    vec3 c2 = ThreeC2[color_order];
+    vec3 c3 = ThreeC3[color_order];
     vec3 c4 = Black;
 
     if (subpixel_type == 1)
@@ -279,13 +293,13 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     }
     else if (subpixel_type == 2)
     {
-        c1 = color_swap ? Yellow : Magenta;
-        c2 = color_swap ? Blue : Green;
+        c1 = TwoC1[color_order];
+        c2 = TwoC2[color_order];
     }
     else if (subpixel_type == 3)
     {
-        c1 = color_swap ? Yellow : Magenta;
-        c2 = color_swap ? Blue : Green;
+        c1 = TwoC1[color_order];
+        c2 = TwoC2[color_order];
         c3 = Black;
     }
 

--- a/crt/shaders/crt-yah/common/subpixel-color.h
+++ b/crt/shaders/crt-yah/common/subpixel-color.h
@@ -15,14 +15,51 @@ const vec3 Magenta = vec3(1.0, 0.0, 1.0);
 const vec3 Yellow = vec3(1.0, 1.0, 0.0);
 const vec3 Cyan = vec3(0.0, 1.0, 1.0);
 
-// color combinations of three
-const vec3 ThreeC1[4] = vec3[4](Red,   Blue,  Red,   Green);
-const vec3 ThreeC2[4] = vec3[4](Green, Green, Blue,  Blue);
-const vec3 ThreeC3[4] = vec3[4](Blue,  Red,   Green, Red);
+// shorthands
+const vec3 W = White;
+const vec3 X = Black;
+const vec3 R = Red;
+const vec3 G = Green;
+const vec3 B = Blue;
+const vec3 M = Magenta;
+const vec3 Y = Yellow;
+const vec3 C = Cyan;
 
-// color combinations of two
-const vec3 TwoC1[4] = vec3[4](Green,   Magenta, Blue,   Yellow);
-const vec3 TwoC2[4] = vec3[4](Magenta, Green,   Yellow, Blue);
+// lookup tables for three colors
+//   row is the sub-pixel type
+//     0: white, black
+//     1: green, magenta
+//     2: green, magenta, (black)
+//     3: red, green, blue
+//     4: red, green, blue, (black)
+//   column is the sub-pixel order
+//     0: red/green/blue, green/magenta
+//     1: blue/green/red, magenta/green
+//     3: red/blue/Green, blue/yellow
+//     4: green/blue/red, yellow/blue
+const vec3 MaskColor1[20] = vec3[20](
+    W,   W,   W,   W,
+    G,   M,   B,   Y,
+    G,   M,   B,   Y,
+    R,   B,   R,   G,
+    R,   B,   R,   G
+);
+
+const vec3 MaskColor2[20] = vec3[20](
+    X,   X,   X,   X,
+    M,   G,   Y,   B,
+    M,   G,   Y,   B,
+    G,   G,   B,   B,
+    G,   G,   B,   B
+);
+
+const vec3 MaskColor3[20] = vec3[20](
+    B,   R,   G,   R,
+    B,   R,   G,   R,
+    X,   X,   X,   X,
+    B,   R,   G,   R,
+    B,   R,   G,   R
+);
 
 // Returns an offset to shift the given pixel coordinate by x-amount for every second y-block.
 // @pixCoord - the pixel coordinate
@@ -86,6 +123,7 @@ vec3 get_subpixel_color(vec2 pixCoord, vec3 c1, vec3 c2, vec3 c3, vec3 c4)
 //   which is usually the texture coordinate multiplied by the output size.
 // @size - the mask size
 // @mask_type - the mask type [1, 3]
+//   0: Off
 //   1: Aperture-grille
 //   2: Slot-mask
 //   3: Shadow-mask
@@ -96,42 +134,29 @@ vec3 get_subpixel_color(vec2 pixCoord, vec3 c1, vec3 c2, vec3 c3, vec3 c4)
 //   4: red, green, blue
 //   5: red, green, blue, black
 // @color_order - determines the order of sub-pixel colors
-//   0: red/green/blue, green/magenta
-//   1: blue/green/red, magenta/green
-//   2: red/blue/Green, blue/yellow
-//   3: green/blue/red, yellow/blue
+//   1: red/green/blue, green/magenta
+//   2: blue/green/red, magenta/green
+//   3: red/blue/Green, blue/yellow
+//   4: green/blue/red, yellow/blue
 vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_type, int color_order)
 {
     vec3 color = White;
 
-    if (mask_type == 0 || subpixel_type == 0)
+    if (mask_type == 0)
     {
         return color;
     }
 
     pixCoord /= size;
 
-    vec3 c1 = ThreeC1[color_order];
-    vec3 c2 = ThreeC2[color_order];
-    vec3 c3 = ThreeC3[color_order];
-    vec3 c4 = Black;
+    subpixel_type -= 1;
+    color_order -= 1;
+    int lutIndex = (subpixel_type * 4) + color_order;
 
-    if (subpixel_type == 1)
-    {
-        c1 = White;
-        c2 = Black;
-    }
-    else if (subpixel_type == 2)
-    {
-        c1 = TwoC1[color_order];
-        c2 = TwoC2[color_order];
-    }
-    else if (subpixel_type == 3)
-    {
-        c1 = TwoC1[color_order];
-        c2 = TwoC2[color_order];
-        c3 = Black;
-    }
+    vec3 c1 = MaskColor1[lutIndex];
+    vec3 c2 = MaskColor2[lutIndex];
+    vec3 c3 = MaskColor3[lutIndex];
+    vec3 c4 = Black;
 
     // Aperture-grille
     // Slot-mask
@@ -142,7 +167,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         float gap = floor((0.5 * size) + EPSILON) / size;
 
         // green, magenta, black
-        if (subpixel_type == 3)
+        if (subpixel_type == 2)
         {
             // for size larger 1
             pixCoord += size > 1
@@ -150,7 +175,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
                 : vec2(0.0, 0.0);
         }
         // red, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             // for size larger 1
             pixCoord += size > 1
@@ -164,18 +189,18 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     {
         // white, black
         // green, magenta
-        if (subpixel_type == 1 || subpixel_type == 2)
+        if (subpixel_type == 0 || subpixel_type == 1)
         {
             color = get_subpixel_color(pixCoord, c1, c2);
         }
         // green, magenta, black
         // red, green, blue
-        else if (subpixel_type == 3 || subpixel_type == 4)
+        else if (subpixel_type == 2 || subpixel_type == 3)
         {
             color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // red, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             color = get_subpixel_color(pixCoord, c1, c2, c3, c4);
         }
@@ -185,7 +210,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     {
         // white, black
         // magenta, green
-        if (subpixel_type == 1 || subpixel_type == 2)
+        if (subpixel_type == 0 || subpixel_type == 1)
         {
             pixCoord += shift_y_every_x(pixCoord, 2.0, 2.0);
 
@@ -195,7 +220,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         }
         // green, magenta, black
         // red, green, blue
-        else if (subpixel_type == 3 || subpixel_type == 4)
+        else if (subpixel_type == 2 || subpixel_type == 3)
         {
             pixCoord += shift_y_every_x(pixCoord, 2.0, 3.0);
 
@@ -204,7 +229,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
                 : get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // red, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             pixCoord += shift_y_every_x(pixCoord, 2.0, 4.0);
 
@@ -218,7 +243,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     {
         // white, black
         // magenta, green
-        if(subpixel_type == 1 || subpixel_type == 2)
+        if(subpixel_type == 0 || subpixel_type == 1)
         {
             pixCoord += shift_x_every_y(pixCoord, 1.0, 1.0);
 
@@ -226,7 +251,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         }
         // green, magenta, black
         // reg, green, blue
-        else if (subpixel_type == 3 || subpixel_type == 4)
+        else if (subpixel_type == 2 || subpixel_type == 3)
         {
             pixCoord += shift_x_every_y(pixCoord, 1.5, 1.0);
             pixCoord.x *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
@@ -234,7 +259,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
             color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // reg, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             pixCoord += shift_x_every_y(pixCoord, 2.0, 1.0);
 
@@ -251,6 +276,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
 //   which is usually the texture coordinate multiplied by the output size.
 // @size - the mask size
 // @mask_type - the mask type [1, 3]
+//   0: Off
 //   1: Aperture-grille
 //   2: Slot-mask
 //   3: Shadow-mask
@@ -261,17 +287,17 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
 //   4: red, green, blue
 //   5: red, green, blue, black
 // @color_order - determines the order of sub-pixel colors
-//   0: red/green/blue, green/magenta
-//   1: blue/green/red, magenta/green
-//   2: red/blue/Green, blue/yellow
-//   3: green/blue/red, yellow/blue
+//   1: red/green/blue, green/magenta
+//   2: blue/green/red, magenta/green
+//   3: red/blue/Green, blue/yellow
+//   4: green/blue/red, yellow/blue
 // @radius - the corner radius of the sub-pixel
 // @smoothness - the smoothness of the sub-pixel
 vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_type, int color_order, float radius, float smoothness)
 {
     vec3 color = White;
 
-    if (mask_type == 0 || subpixel_type == 0)
+    if (mask_type == 0)
     {
         return color;
     }
@@ -281,27 +307,14 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     vec2 bounds = vec2(1.0, 1.0);
     vec2 scale = vec2(1.0, 1.0);
 
-    vec3 c1 = ThreeC1[color_order];
-    vec3 c2 = ThreeC2[color_order];
-    vec3 c3 = ThreeC3[color_order];
-    vec3 c4 = Black;
+    subpixel_type -= 1;
+    color_order -= 1;
+    int lutIndex = (subpixel_type * 4) + color_order;
 
-    if (subpixel_type == 1)
-    {
-        c1 = White;
-        c2 = Black;
-    }
-    else if (subpixel_type == 2)
-    {
-        c1 = TwoC1[color_order];
-        c2 = TwoC2[color_order];
-    }
-    else if (subpixel_type == 3)
-    {
-        c1 = TwoC1[color_order];
-        c2 = TwoC2[color_order];
-        c3 = Black;
-    }
+    vec3 c1 = MaskColor1[lutIndex];
+    vec3 c2 = MaskColor2[lutIndex];
+    vec3 c3 = MaskColor3[lutIndex];
+    vec3 c4 = Black;
 
     // Aperture-grille
     // Slot-mask
@@ -312,7 +325,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         float gap = floor(0.5 * size) / size;
 
         // green, magenta, black
-        if (subpixel_type == 3)
+        if (subpixel_type == 2)
         {
             // for size larger 1
             pixCoord += size > 1
@@ -320,7 +333,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
                 : vec2(0.0, 0.0);
         }
         // red, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             // for size larger 1
             pixCoord += size > 1
@@ -334,18 +347,18 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     {
         // white, black
         // magenta, green
-        if (subpixel_type == 1 || subpixel_type == 2)
+        if (subpixel_type == 0 || subpixel_type == 1)
         {
             color = get_subpixel_color(pixCoord, c1, c2);
         }
         // magenta, green, black
         // red, green, blue
-        else if (subpixel_type == 3 || subpixel_type == 4)
+        else if (subpixel_type == 2 || subpixel_type == 3)
         {
             color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // red, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             color = get_subpixel_color(pixCoord, c1, c2, c3, c4);
         }
@@ -378,7 +391,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
 
         // white, black
         // magenta, green
-        if (subpixel_type == 1 || subpixel_type == 2)
+        if (subpixel_type == 0 || subpixel_type == 1)
         {
             pixCoord += shift_y_every_x(pixCoord, 1.5 + shift, 2.0);
             pixCoord.y *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
@@ -388,7 +401,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         }
         // magenta, green, black
         // red, green, blue
-        else if (subpixel_type == 3 || subpixel_type == 4)
+        else if (subpixel_type == 2 || subpixel_type == 3)
         {
             pixCoord += shift_y_every_x(pixCoord, 1.5 + shift, 3.0);
             pixCoord.y *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
@@ -397,7 +410,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
             color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // red, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             pixCoord += shift_y_every_x(pixCoord, 1.5 + shift, 4.0);
             pixCoord.y *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
@@ -414,7 +427,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     {
         // white, black
         // magenta, green
-        if(subpixel_type == 1 || subpixel_type == 2)
+        if(subpixel_type == 0 || subpixel_type == 1)
         {
             pixCoord += shift_x_every_y(pixCoord, 1.0, 1.0);
 
@@ -422,7 +435,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         }
         // magenta, green, black
         // reg, green, blue
-        else if (subpixel_type == 3 || subpixel_type == 4)
+        else if (subpixel_type == 2 || subpixel_type == 3)
         {
             float shift =
                 // correct shape for size 3
@@ -436,7 +449,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
             color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // reg, green, blue, black
-        else if (subpixel_type == 5)
+        else if (subpixel_type == 4)
         {
             pixCoord += shift_x_every_y(pixCoord, 2.0, 1.0);
 

--- a/crt/shaders/crt-yah/common/subpixel-color.h
+++ b/crt/shaders/crt-yah/common/subpixel-color.h
@@ -61,6 +61,8 @@ const vec3 MaskColor3[20] = vec3[20](
     B,   R,   G,   R
 );
 
+const int SubpixelCounts[5] = int[](2, 2, 3, 3, 4);
+
 // Returns an offset to shift the given pixel coordinate by x-amount for every second y-block.
 // @pixCoord - the pixel coordinate
 // @amount - the amount to shift the x-coordinate
@@ -99,22 +101,11 @@ int get_index(float pixCoord, int count)
     return int(floor(mod(pixCoord, count)));
 }
 
-vec3 get_subpixel_color(vec2 pixCoord, vec3 c1, vec3 c2)
+vec3 get_subpixel_color(vec2 pixCoord, vec3 c1, vec3 c2, vec3 c3, vec3 c4, int count)
 {
-    vec3 colors[2] = { c1, c2 };
-    return colors[get_index(pixCoord.x, 2)];
-}
+    vec3 colors[4] = vec3[]( c1, c2, c3, c4 );
 
-vec3 get_subpixel_color(vec2 pixCoord, vec3 c1, vec3 c2, vec3 c3)
-{
-    vec3 colors[3] = { c1, c2, c3 };
-    return colors[get_index(pixCoord.x, 3)];
-}
-
-vec3 get_subpixel_color(vec2 pixCoord, vec3 c1, vec3 c2, vec3 c3, vec3 c4)
-{
-    vec3 colors[4] = { c1, c2, c3, c4 };
-    return colors[get_index(pixCoord.x, 4)];
+    return colors[get_index(pixCoord.x, count)];
 }
 
 // Gets the sub-pixel color of a mask with full saturation.
@@ -184,26 +175,12 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         }
     }
 
+    float color_factor = 1.0;
+
     // Aperture-grille
     if (mask_type == 1)
     {
-        // white, black
-        // green, magenta
-        if (subpixel_type == 0 || subpixel_type == 1)
-        {
-            color = get_subpixel_color(pixCoord, c1, c2);
-        }
-        // green, magenta, black
-        // red, green, blue
-        else if (subpixel_type == 2 || subpixel_type == 3)
-        {
-            color = get_subpixel_color(pixCoord, c1, c2, c3);
-        }
-        // red, green, blue, black
-        else if (subpixel_type == 4)
-        {
-            color = get_subpixel_color(pixCoord, c1, c2, c3, c4);
-        }
+        // no coordinate transformation
     }
     // Slot-mask
     else if (mask_type == 2)
@@ -213,30 +190,21 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         if (subpixel_type == 0 || subpixel_type == 1)
         {
             pixCoord += shift_y_every_x(pixCoord, 2.0, 2.0);
-
-            color = get_index(pixCoord.y, 4) == 0
-                ? c4
-                : get_subpixel_color(pixCoord, c1, c2);
         }
         // green, magenta, black
         // red, green, blue
         else if (subpixel_type == 2 || subpixel_type == 3)
         {
             pixCoord += shift_y_every_x(pixCoord, 2.0, 3.0);
-
-            color = get_index(pixCoord.y, 4) == 0
-                ? c4
-                : get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // red, green, blue, black
         else if (subpixel_type == 4)
         {
             pixCoord += shift_y_every_x(pixCoord, 2.0, 4.0);
-
-            color = get_index(pixCoord.y, 4) == 0
-                ? c4
-                : get_subpixel_color(pixCoord, c1, c2, c3, c4);
         }
+
+        // set color to 0 for each 4th row
+        color_factor -= float(get_index(pixCoord.y, 4) == 0);
     }
     // Shadow-mask
     else if (mask_type == 3)
@@ -246,8 +214,6 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         if(subpixel_type == 0 || subpixel_type == 1)
         {
             pixCoord += shift_x_every_y(pixCoord, 1.0, 1.0);
-
-            color = get_subpixel_color(pixCoord, c1, c2);
         }
         // green, magenta, black
         // reg, green, blue
@@ -255,19 +221,18 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         {
             pixCoord += shift_x_every_y(pixCoord, 1.5, 1.0);
             pixCoord.x *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
-
-            color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // reg, green, blue, black
         else if (subpixel_type == 4)
         {
             pixCoord += shift_x_every_y(pixCoord, 2.0, 1.0);
-
-            color = get_subpixel_color(pixCoord, c1, c2, c3, c4);
         }
     }
 
-    return color;
+    color = get_subpixel_color(
+        pixCoord, c1, c2, c3, c4, SubpixelCounts[subpixel_type]);
+
+    return color * color_factor;
 }
 
 // Gets the sub-pixel color of a mask with full saturation.
@@ -345,24 +310,7 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
     // Aperture-grille
     if (mask_type == 1)
     {
-        // white, black
-        // magenta, green
-        if (subpixel_type == 0 || subpixel_type == 1)
-        {
-            color = get_subpixel_color(pixCoord, c1, c2);
-        }
-        // magenta, green, black
-        // red, green, blue
-        else if (subpixel_type == 2 || subpixel_type == 3)
-        {
-            color = get_subpixel_color(pixCoord, c1, c2, c3);
-        }
-        // red, green, blue, black
-        else if (subpixel_type == 4)
-        {
-            color = get_subpixel_color(pixCoord, c1, c2, c3, c4);
-        }
-
+        // no coordinate transformation
         // for max 8K vertical resolution
         bounds = vec2(1.0, 1080.0 * 8.0);
     }
@@ -396,8 +344,6 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
             pixCoord += shift_y_every_x(pixCoord, 1.5 + shift, 2.0);
             pixCoord.y *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
             pixCoord.y += offset;
-
-            color = get_subpixel_color(pixCoord, c1, c2);
         }
         // magenta, green, black
         // red, green, blue
@@ -406,8 +352,6 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
             pixCoord += shift_y_every_x(pixCoord, 1.5 + shift, 3.0);
             pixCoord.y *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
             pixCoord.y += offset;
-
-            color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // red, green, blue, black
         else if (subpixel_type == 4)
@@ -415,8 +359,6 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
             pixCoord += shift_y_every_x(pixCoord, 1.5 + shift, 4.0);
             pixCoord.y *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
             pixCoord.y += offset;
-
-            color = get_subpixel_color(pixCoord, c1, c2, c3, c4);
         }
 
         bounds = vec2(1.0, height);
@@ -430,8 +372,6 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
         if(subpixel_type == 0 || subpixel_type == 1)
         {
             pixCoord += shift_x_every_y(pixCoord, 1.0, 1.0);
-
-            color = get_subpixel_color(pixCoord, c1, c2);
         }
         // magenta, green, black
         // reg, green, blue
@@ -445,17 +385,16 @@ vec3 get_subpixel_color(vec2 pixCoord, int size, int mask_type, int subpixel_typ
 
             pixCoord += shift_x_every_y(pixCoord, 1.5 + shift, 1.0);
             pixCoord.x *= 1.0 + EPSILON; // avoid color artifacts due to half pixel shift
-
-            color = get_subpixel_color(pixCoord, c1, c2, c3);
         }
         // reg, green, blue, black
         else if (subpixel_type == 4)
         {
             pixCoord += shift_x_every_y(pixCoord, 2.0, 1.0);
-
-            color = get_subpixel_color(pixCoord, c1, c2, c3, c4);
         }
     }
+
+    color = get_subpixel_color(
+        pixCoord, c1, c2, c3, c4, SubpixelCounts[subpixel_type]);
 
     if (size > 2)
     {

--- a/crt/shaders/crt-yah/crt-yah.layout.h
+++ b/crt/shaders/crt-yah/crt-yah.layout.h
@@ -14,6 +14,9 @@ layout(std140, set = 0, binding = 0) uniform UBO
     float SCREEN_FREQUENCY;
     float SCREEN_INTERLACED;
     float SHARP_AMOUNT;
+    float HALATION_INTENSITY;
+    float HALATION_DIFFUSION;
+    float HALATION_INFLUENCE;
 } global;
 
 layout (push_constant) uniform Push
@@ -40,11 +43,9 @@ layout (push_constant) uniform Push
     float MASK_SCALE;
     float MASK_TYPE;
     float MASK_SUBPIXEL;
+    float MASK_SUBPIXEL_ORDER;
     float MASK_SUBPIXEL_SHAPE;
     float MASK_COLOR_BLEED;
-    float HALATION_INTENSITY;
-    float HALATION_DIFFUSION;
-    float HALATION_INFLUENCE;
     float CRT_CURVATURE_AMOUNT;
     float CRT_VIGNETTE_AMOUNT;
     float CRT_NOISE_AMOUNT;

--- a/crt/shaders/crt-yah/crt-yah.stage-f.core.h
+++ b/crt/shaders/crt-yah/crt-yah.stage-f.core.h
@@ -408,14 +408,14 @@ vec3 get_mask(vec2 tex_coord)
     int subpixel_type = int(INPUT_MASK_PROFILE.x);
     int subpixel_size = int(INPUT_MASK_PROFILE.y);
     float subpixel_smoothness = INPUT_MASK_PROFILE.z;
-    bool subpixel_color_swap = bool(INPUT_MASK_PROFILE.w);
+    int subpixel_color_order = int(INPUT_MASK_PROFILE.w);
 
     vec3 mask = get_subpixel_color(
         pix_coord,
         subpixel_size,
         subpixel_mask,
         subpixel_type,
-        subpixel_color_swap,
+        subpixel_color_order,
         1.0,
         subpixel_smoothness);
 

--- a/crt/shaders/crt-yah/crt-yah.stage-f.h
+++ b/crt/shaders/crt-yah/crt-yah.stage-f.h
@@ -3,15 +3,14 @@ layout(location = 0) in vec2 TexCoord;
 layout(location = 1) in vec2 ScanTexCoord;
 layout(location = 2) in vec2 TexSize;
 layout(location = 3) flat in int ScreenOrientation;
-layout(location = 4) in float ScreenMultiple;
-layout(location = 5) in float ScreenMultipleAuto;
-layout(location = 6) in float BrightnessCompensation;
-layout(location = 7) in vec4 MaskProfile;
-layout(location = 8) in vec4 BeamProfile;
-layout(location = 9) in float AntiRining;
-layout(location = 10) in vec2 FloorProfile;
-layout(location = 11) flat in uvec2 FrameCounts;
-layout(location = 12) in mat4x4 BeamFilter;
+layout(location = 4) in vec3 ScreenMultipleProfile;
+layout(location = 5) in float BrightnessCompensation;
+layout(location = 6) in vec4 MaskProfile;
+layout(location = 7) in vec4 BeamProfile;
+layout(location = 8) in float AntiRining;
+layout(location = 9) in vec2 FloorProfile;
+layout(location = 10) flat in uvec2 FrameCounts;
+layout(location = 11) in mat4x4 BeamFilter;
 layout(location = 0) out vec4 FragColor;
 
 #ifdef IS_SINGLE_PASS
@@ -34,8 +33,9 @@ layout(location = 0) out vec4 FragColor;
 
 // required by crt-yah.stage-f.core.h
 #define INPUT_SCREEN_ORIENTATION ScreenOrientation
-#define INPUT_SCREEN_MULTIPLE ScreenMultiple
-#define INPUT_SCREEN_MULTIPLE_AUTO ScreenMultipleAuto
+#define INPUT_SCREEN_MULTIPLE (ScreenMultipleProfile.x)
+#define INPUT_SCREEN_MULTIPLE_AUTO (ScreenMultipleProfile.y)
+#define INPUT_SCREEN_MULTIPLE_NATIVE (ScreenMultipleProfile.z)
 #define INPUT_BRIGHTNESS_COMPENSATION BrightnessCompensation
 #define INPUT_MASK_PROFILE MaskProfile
 #define INPUT_BEAM_PROFILE BeamProfile

--- a/crt/shaders/crt-yah/crt-yah.stage-v.core.h
+++ b/crt/shaders/crt-yah/crt-yah.stage-v.core.h
@@ -79,14 +79,9 @@ vec4 get_mask_profile()
         PARAM_MASK_TYPE == 3 ? clamp((subpixel_size - 2.0) * 0.25, 0.0, 1.0) : 0.0;
     subpixel_smoothness *= PARAM_MASK_SUBPIXEL_SHAPE;
 
-    int subpixel_type =
-        // black, white to magenta, green
-        PARAM_MASK_SUBPIXEL == 1 ? PARAM_MASK_SUBPIXEL + 1 :
-        PARAM_MASK_SUBPIXEL;
+    int subpixel_type = PARAM_MASK_SUBPIXEL;
 
-    bool subpixel_color_swap =
-        // magenta, green to blue, yellow
-        PARAM_MASK_SUBPIXEL == 1;
+    bool subpixel_color_swap = PARAM_MASK_SUBPIXEL_ORDER > 1;
 
     return vec4(subpixel_type, subpixel_size, subpixel_smoothness, subpixel_color_swap);
 }

--- a/crt/shaders/crt-yah/crt-yah.stage-v.core.h
+++ b/crt/shaders/crt-yah/crt-yah.stage-v.core.h
@@ -81,9 +81,9 @@ vec4 get_mask_profile()
 
     int subpixel_type = PARAM_MASK_SUBPIXEL;
 
-    bool subpixel_color_swap = PARAM_MASK_SUBPIXEL_ORDER > 1;
+    int subpixel_color_order = PARAM_MASK_SUBPIXEL_ORDER - 1;
 
-    return vec4(subpixel_type, subpixel_size, subpixel_smoothness, subpixel_color_swap);
+    return vec4(subpixel_type, subpixel_size, subpixel_smoothness, subpixel_color_order);
 }
 
 float get_brightness_compensation()

--- a/crt/shaders/crt-yah/crt-yah.stage-v.core.h
+++ b/crt/shaders/crt-yah/crt-yah.stage-v.core.h
@@ -57,8 +57,8 @@ vec4 get_mask_profile()
 
     float subpixel_size = pixel_size / subpixel_count;
 
-    // auto scale (consider applied screen-multiple)
-    subpixel_size = floor(subpixel_size * INPUT_SCREEN_MULTIPLE);
+    // auto scale by native multiple
+    subpixel_size = floor(subpixel_size * INPUT_SCREEN_MULTIPLE_NATIVE);
     // limit after auto scale
     subpixel_size = max(1.0, subpixel_size);
 

--- a/crt/shaders/crt-yah/crt-yah.stage-v.core.h
+++ b/crt/shaders/crt-yah/crt-yah.stage-v.core.h
@@ -81,7 +81,7 @@ vec4 get_mask_profile()
 
     int subpixel_type = PARAM_MASK_SUBPIXEL;
 
-    int subpixel_color_order = PARAM_MASK_SUBPIXEL_ORDER - 1;
+    int subpixel_color_order = PARAM_MASK_SUBPIXEL_ORDER;
 
     return vec4(subpixel_type, subpixel_size, subpixel_smoothness, subpixel_color_order);
 }

--- a/crt/shaders/crt-yah/crt-yah.stage-v.h
+++ b/crt/shaders/crt-yah/crt-yah.stage-v.h
@@ -5,20 +5,20 @@ layout(location = 0) out vec2 TexCoord;
 layout(location = 1) out vec2 ScanTexCoord;
 layout(location = 2) out vec2 TexSize;
 layout(location = 3) flat out int ScreenOrientation;
-layout(location = 4) out float ScreenMultiple;
-layout(location = 5) out float ScreenMultipleAuto;
-layout(location = 6) out float BrightnessCompensation;
-layout(location = 7) out vec4 MaskProfile;
-layout(location = 8) out vec4 BeamProfile;
-layout(location = 9) out float AntiRining;
-layout(location = 10) out vec2 FloorProfile;
-layout(location = 11) flat out uvec2 FrameCounts;
-layout(location = 12) out mat4x4 BeamFilter;
+layout(location = 4) out vec3 ScreenMultipleProfile;
+layout(location = 5) out float BrightnessCompensation;
+layout(location = 6) out vec4 MaskProfile;
+layout(location = 7) out vec4 BeamProfile;
+layout(location = 8) out float AntiRining;
+layout(location = 9) out vec2 FloorProfile;
+layout(location = 10) flat out uvec2 FrameCounts;
+layout(location = 11) out mat4x4 BeamFilter;
 
 // required by crt-yah.stage-v.core.h
 #define INPUT_SCREEN_ORIENTATION ScreenOrientation
-#define INPUT_SCREEN_MULTIPLE ScreenMultiple
-#define INPUT_SCREEN_MULTIPLE_AUTO ScreenMultipleAuto
+#define INPUT_SCREEN_MULTIPLE (ScreenMultipleProfile.x)
+#define INPUT_SCREEN_MULTIPLE_AUTO (ScreenMultipleProfile.y)
+#define INPUT_SCREEN_MULTIPLE_NATIVE (ScreenMultipleProfile.z)
 #define INPUT_MASK_PROFILE MaskProfile
 
 #include "crt-yah.stage-v.core.h"
@@ -31,8 +31,9 @@ void main()
     ScanTexCoord = Coord;
 
     ScreenOrientation = get_orientation(global.OutputSize.xy, PARAM_SCREEN_ORIENTATION);
-    ScreenMultiple = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, -PARAM_SCREEN_SCALE);
-    ScreenMultipleAuto = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, 0.0);
+    ScreenMultipleProfile.x = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, -PARAM_SCREEN_SCALE);
+    ScreenMultipleProfile.y = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, 0.0);
+    ScreenMultipleProfile.z = get_auto_multiple(global.OriginalSize.xy, ScreenOrientation, 0.0);
     MaskProfile = get_mask_profile();
     BeamProfile = get_beam_profile();
     BeamFilter = get_beam_filter();

--- a/crt/shaders/crt-yah/halation-blur.layout.h
+++ b/crt/shaders/crt-yah/halation-blur.layout.h
@@ -6,10 +6,6 @@ layout(std140, set = 0, binding = 0) uniform UBO
     vec4 OutputSize;
     vec4 FinalViewportSize;
     float GLOBAL_MASTER;
-} global;
-
-layout (push_constant) uniform Push
-{
     float HALATION_INTENSITY;
     float HALATION_DIFFUSION;
-} param;
+} global;

--- a/crt/shaders/crt-yah/ntsc-pass1.stage-v.h
+++ b/crt/shaders/crt-yah/ntsc-pass1.stage-v.h
@@ -34,7 +34,6 @@ void main()
 {
     gl_Position = global.MVP * Position;
 
-    float multiple_auto = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, 0.0);
     float multiple = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, -(PARAM_SCREEN_SCALE + PARAM_NTSC_SCALE));
     float screen_scale = 1.0 / multiple;
 

--- a/crt/shaders/crt-yah/ntsc-pass2.stage-v.h
+++ b/crt/shaders/crt-yah/ntsc-pass2.stage-v.h
@@ -28,7 +28,6 @@ void main()
     gl_Position = global.MVP * Position;
     TexCoord = Coord;
 
-    float multiple_auto = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, 0.0);
     float multiple = get_screen_multiple(global.OriginalSize.xy, ScreenOrientation, -(PARAM_SCREEN_SCALE + PARAM_NTSC_SCALE));
     float screen_scale = 1.0 / multiple;
 

--- a/crt/shaders/crt-yah/parameters-single-pass.h
+++ b/crt/shaders/crt-yah/parameters-single-pass.h
@@ -3,7 +3,7 @@
 
 // Screen parameters
 #pragma parameter SCREEN_ORIENTATION "·  Screen > Orientation  (0-Auto, 1-Horizontal, 2-Vertical)" 0.0 0.0 2.0 1.0
-#pragma parameter SCREEN_RESOLUTION_SCALE "  ⁵Screen > Resolution  (1-Native, 2,3-Low/+, 4,5-High/+)" 2.0 1.0 5.0 1.0
+#pragma parameter SCREEN_RESOLUTION_SCALE "  ⁵Screen > Resolution  (1-Native, 2/3-Low/+, 4/5-High/+)" 2.0 1.0 5.0 1.0
 #pragma parameter SCREEN_FREQUENCY "  ⁴Screen > Frequency  (30Hz .. 60Hz)" 60.0 30.0 60.0 10.0
 #pragma parameter SCREEN_INTERLACED "   Screen > Interlaced²⁴  (0-None .. 1-Full)" 0.0 0.0 1.0 0.05
 
@@ -30,7 +30,8 @@
 #pragma parameter MASK_INTENSITY "·  Mask > Intensity¹²³  (0-None .. 1-Full)" 0.5 0.0 1.0 0.05
 #pragma parameter MASK_BLEND "   Mask > Blend²  (0-Multiplicative .. 1-Additive)" 0.25 0.0 1.0 0.05
 #pragma parameter MASK_TYPE "   Mask > Type²  (1-Aperture, 2-Slot, 3-Shadow)" 1.0 1.0 3.0 1.0
-#pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-BY, 2,3-MG/x, 4,5-RGB/x)" 4.0 1.0 5.0 1.0
+#pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-Mono, 2-MG, 3-MGx, 4-RGB, 5-RGBx)" 4.0 1.0 5.0 1.0
+#pragma parameter MASK_SUBPIXEL_ORDER "   Mask > Sub-Pixel Order  (1-MG/RGB, 2-BY/BGR)" 1.0 1.0 2.0 1.0
 #pragma parameter MASK_SUBPIXEL_SHAPE "   Mask > Sub-Pixel Shape²  (0-Sharp .. 1-Smooth)  [4K]" 1.0 0.0 1.0 0.25
 #pragma parameter MASK_COLOR_BLEED "   Mask > Color Bleed¹²  (0-None .. 1-Full)" 0.25 0.0 1.0 0.25
 #pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 4.0 0.5

--- a/crt/shaders/crt-yah/parameters-single-pass.h
+++ b/crt/shaders/crt-yah/parameters-single-pass.h
@@ -4,7 +4,6 @@
 // Screen parameters
 #pragma parameter SCREEN_ORIENTATION "·  Screen > Orientation  (0-Auto, 1-Horizontal, 2-Vertical)" 0.0 0.0 2.0 1.0
 #pragma parameter SCREEN_RESOLUTION_SCALE "  ⁵Screen > Resolution  (1-Native, 2,3-Low/+, 4,5-High/+)" 2.0 1.0 5.0 1.0
-#pragma parameter SCREEN_SCALE "   Screen > Scale⁵  (-Down / 0-Auto / +Up)" 0.0 -2.0 2.0 0.05
 #pragma parameter SCREEN_FREQUENCY "  ⁴Screen > Frequency  (30Hz .. 60Hz)" 60.0 30.0 60.0 10.0
 #pragma parameter SCREEN_INTERLACED "   Screen > Interlaced²⁴  (0-None .. 1-Full)" 0.0 0.0 1.0 0.05
 
@@ -25,6 +24,7 @@
 #pragma parameter BEAM_FILTER "   Scanlines > Beam Filter  (-Blocky .. +Blurry)" -0.25 -1.0 1.0 0.05
 #pragma parameter ANTI_RINGING "   Scanlines > Anti-Ringing  (0-None .. 1-Full)" 1.0 0.0 1.0 0.1
 #pragma parameter SCANLINES_COLOR_BURN "   Scanlines > Color Burn¹  (0-None .. 1-Full)" 1.0 0.0 1.0 0.25
+#pragma parameter SCREEN_SCALE "   Scanlines > Scale⁵  (-Down / 0-Auto / +Up)" 0.0 -4.0 2.0 0.05
 
 // Mask parameters
 #pragma parameter MASK_INTENSITY "·  Mask > Intensity¹²³  (0-None .. 1-Full)" 0.5 0.0 1.0 0.05
@@ -33,7 +33,7 @@
 #pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-BY, 2,3-MG/x, 4,5-RGB/x)" 4.0 1.0 5.0 1.0
 #pragma parameter MASK_SUBPIXEL_SHAPE "   Mask > Sub-Pixel Shape²  (0-Sharp .. 1-Smooth)  [4K]" 1.0 0.0 1.0 0.25
 #pragma parameter MASK_COLOR_BLEED "   Mask > Color Bleed¹²  (0-None .. 1-Full)" 0.25 0.0 1.0 0.25
-#pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 2.0 0.5
+#pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 4.0 0.5
 
 // CRT parameters
 #pragma parameter CRT_CURVATURE_AMOUNT "·  CRT > Curvature¹  (0-None .. 1-Full)" 0.0 0.0 1.0 0.05

--- a/crt/shaders/crt-yah/parameters-single-pass.h
+++ b/crt/shaders/crt-yah/parameters-single-pass.h
@@ -31,7 +31,7 @@
 #pragma parameter MASK_BLEND "   Mask > Blend²  (0-Multiplicative .. 1-Additive)" 0.25 0.0 1.0 0.05
 #pragma parameter MASK_TYPE "   Mask > Type²  (1-Aperture, 2-Slot, 3-Shadow)" 1.0 1.0 3.0 1.0
 #pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-Mono, 2-MG, 3-MGx, 4-RGB, 5-RGBx)" 4.0 1.0 5.0 1.0
-#pragma parameter MASK_SUBPIXEL_ORDER "   Mask > Sub-Pixel Order  (1-MG/RGB, 2-BY/BGR)" 1.0 1.0 2.0 1.0
+#pragma parameter MASK_SUBPIXEL_ORDER "   Mask > Sub-Pixel Order  (1-RGB, 2-BGR, 3-RBG, 4-GBR)" 1.0 1.0 4.0 1.0
 #pragma parameter MASK_SUBPIXEL_SHAPE "   Mask > Sub-Pixel Shape²  (0-Sharp .. 1-Smooth)  [4K]" 1.0 0.0 1.0 0.25
 #pragma parameter MASK_COLOR_BLEED "   Mask > Color Bleed¹²  (0-None .. 1-Full)" 0.25 0.0 1.0 0.25
 #pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 4.0 0.5

--- a/crt/shaders/crt-yah/parameters.h
+++ b/crt/shaders/crt-yah/parameters.h
@@ -4,7 +4,6 @@
 // Screen parameters
 #pragma parameter SCREEN_ORIENTATION "·  Screen > Orientation  (0-Auto, 1-Horizontal, 2-Vertical)" 0.0 0.0 2.0 1.0
 #pragma parameter SCREEN_RESOLUTION_SCALE "  ⁵Screen > Resolution  (1-Native, 2,3-Low/+, 4,5-High/+)" 2.0 1.0 5.0 1.0
-#pragma parameter SCREEN_SCALE "   Screen > Scale⁵  (-Down / 0-Auto / +Up)" 0.0 -2.0 2.0 0.05
 #pragma parameter SCREEN_FREQUENCY "  ⁴Screen > Frequency  (30Hz .. 60Hz)" 60.0 30.0 60.0 10.0
 #pragma parameter SCREEN_INTERLACED "   Screen > Interlaced²⁴  (0-None .. 1-Full)" 0.0 0.0 1.0 0.05
 
@@ -28,6 +27,7 @@
 #pragma parameter ANTI_RINGING "   Scanlines > Anti-Ringing  (0-None .. 1-Full)" 1.0 0.0 1.0 0.1
 #pragma parameter SCANLINES_COLOR_BURN "   Scanlines > Color Burn¹  (0-None .. 1-Full)" 1.0 0.0 1.0 0.25
 #pragma parameter SCANLINES_OFFSET "   Scanlines > Offset⁴  (-Static / 0-None / +Jitter)" 0.25 -1.0 1.0 0.05
+#pragma parameter SCREEN_SCALE "   Scanlines > Scale⁵  (-Down / 0-Auto / +Up)" 0.0 -4.0 2.0 0.05
 
 // Mask parameters
 #pragma parameter MASK_INTENSITY "·  Mask > Intensity¹²³  (0-None .. 1-Full)" 0.5 0.0 1.0 0.05
@@ -36,7 +36,7 @@
 #pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-BY, 2,3-MG/x, 4,5-RGB/x)" 4.0 1.0 5.0 1.0
 #pragma parameter MASK_SUBPIXEL_SHAPE "   Mask > Sub-Pixel Shape²  (0-Sharp .. 1-Smooth)  [4K]" 1.0 0.0 1.0 0.25
 #pragma parameter MASK_COLOR_BLEED "   Mask > Color Bleed¹²  (0-None .. 1-Full)" 0.25 0.0 1.0 0.25
-#pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 2.0 0.5
+#pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 4.0 0.5
 
 // Deconverge parameters
 #pragma parameter DECONVERGE_LINEAR "·  Deconverge > Linear Amount¹  (0-None .. -/+ 1-Full)" 0.25 -2.0 2.0 0.05
@@ -56,8 +56,8 @@
 #pragma parameter NTSC_PHASE "   NTSC > Chroma Phase  (0-Auto, 1-Two, 2-Three)" 1.0 0.0 2.0 1.0
 #pragma parameter NTSC_SAMPLES "   NTSC > Chroma Samples  (¼-Min .. 1-Max)" 1.0 0.25 1.0 0.25
 #pragma parameter NTSC_SHIFT "   NTSC > Chroma Shift  (-left .. +right)" 0.0 -1.0 1.0 0.1
-#pragma parameter NTSC_SCALE "   NTSC > Scale⁵  (-Down / 0-Auto / +Up)" 0.0 -0.5 0.5 0.05
 #pragma parameter NTSC_JITTER "   NTSC > Offset⁴  (-Merge / 0-Static / +Jitter)" 1.0 -1.0 1.0 0.1
+#pragma parameter NTSC_SCALE "   NTSC > Scale⁵  (-Down / 0-Auto / +Up)" 0.0 -0.5 0.5 0.05
 
 // CRT parameters
 #pragma parameter CRT_CURVATURE_AMOUNT "·  CRT > Curvature¹  (0-None .. 1-Full)" 0.0 0.0 1.0 0.05

--- a/crt/shaders/crt-yah/parameters.h
+++ b/crt/shaders/crt-yah/parameters.h
@@ -34,7 +34,7 @@
 #pragma parameter MASK_BLEND "   Mask > Blend²  (0-Multiplicative .. 1-Additive)" 0.25 0.0 1.0 0.05
 #pragma parameter MASK_TYPE "   Mask > Type²  (1-Aperture, 2-Slot, 3-Shadow)" 1.0 1.0 3.0 1.0
 #pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-Mono, 2-MG, 3-MGx, 4-RGB, 5-RGBx)" 4.0 1.0 5.0 1.0
-#pragma parameter MASK_SUBPIXEL_ORDER "   Mask > Sub-Pixel Order  (1-MG/RGB, 2-BY/BGR)" 1.0 1.0 2.0 1.0
+#pragma parameter MASK_SUBPIXEL_ORDER "   Mask > Sub-Pixel Order  (1-RGB, 2-BGR, 3-RBG, 4-GBR)" 1.0 1.0 4.0 1.0
 #pragma parameter MASK_SUBPIXEL_SHAPE "   Mask > Sub-Pixel Shape²  (0-Sharp .. 1-Smooth)  [4K]" 1.0 0.0 1.0 0.25
 #pragma parameter MASK_COLOR_BLEED "   Mask > Color Bleed¹²  (0-None .. 1-Full)" 0.25 0.0 1.0 0.25
 #pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 4.0 0.5

--- a/crt/shaders/crt-yah/parameters.h
+++ b/crt/shaders/crt-yah/parameters.h
@@ -3,7 +3,7 @@
 
 // Screen parameters
 #pragma parameter SCREEN_ORIENTATION "·  Screen > Orientation  (0-Auto, 1-Horizontal, 2-Vertical)" 0.0 0.0 2.0 1.0
-#pragma parameter SCREEN_RESOLUTION_SCALE "  ⁵Screen > Resolution  (1-Native, 2,3-Low/+, 4,5-High/+)" 2.0 1.0 5.0 1.0
+#pragma parameter SCREEN_RESOLUTION_SCALE "  ⁵Screen > Resolution  (1-Native, 2/3-Low/+, 4/5-High/+)" 2.0 1.0 5.0 1.0
 #pragma parameter SCREEN_FREQUENCY "  ⁴Screen > Frequency  (30Hz .. 60Hz)" 60.0 30.0 60.0 10.0
 #pragma parameter SCREEN_INTERLACED "   Screen > Interlaced²⁴  (0-None .. 1-Full)" 0.0 0.0 1.0 0.05
 
@@ -33,7 +33,8 @@
 #pragma parameter MASK_INTENSITY "·  Mask > Intensity¹²³  (0-None .. 1-Full)" 0.5 0.0 1.0 0.05
 #pragma parameter MASK_BLEND "   Mask > Blend²  (0-Multiplicative .. 1-Additive)" 0.25 0.0 1.0 0.05
 #pragma parameter MASK_TYPE "   Mask > Type²  (1-Aperture, 2-Slot, 3-Shadow)" 1.0 1.0 3.0 1.0
-#pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-BY, 2,3-MG/x, 4,5-RGB/x)" 4.0 1.0 5.0 1.0
+#pragma parameter MASK_SUBPIXEL "   Mask > Sub-Pixel²  (1-Mono, 2-MG, 3-MGx, 4-RGB, 5-RGBx)" 4.0 1.0 5.0 1.0
+#pragma parameter MASK_SUBPIXEL_ORDER "   Mask > Sub-Pixel Order  (1-MG/RGB, 2-BY/BGR)" 1.0 1.0 2.0 1.0
 #pragma parameter MASK_SUBPIXEL_SHAPE "   Mask > Sub-Pixel Shape²  (0-Sharp .. 1-Smooth)  [4K]" 1.0 0.0 1.0 0.25
 #pragma parameter MASK_COLOR_BLEED "   Mask > Color Bleed¹²  (0-None .. 1-Full)" 0.25 0.0 1.0 0.25
 #pragma parameter MASK_SCALE "   Mask > Scale⁵  (-1 Down / 0-Auto / +½ Up)" 0.0 -2.0 4.0 0.5

--- a/crt/shaders/crt-yah/parameters.shared.h
+++ b/crt/shaders/crt-yah/parameters.shared.h
@@ -29,6 +29,7 @@ float mix_master(float value, float off_value, float min_value, float max_value)
 #define PARAM_MASK_SCALE param.MASK_SCALE
 #define PARAM_MASK_TYPE int(param.MASK_TYPE)
 #define PARAM_MASK_SUBPIXEL int(param.MASK_SUBPIXEL)
+#define PARAM_MASK_SUBPIXEL_ORDER int(param.MASK_SUBPIXEL_ORDER)
 #define PARAM_MASK_SUBPIXEL_SHAPE param.MASK_SUBPIXEL_SHAPE
 #define PARAM_MASK_COLOR_BLEED mix_master(param.MASK_COLOR_BLEED, 0.0, 0.0, 1.0)
 
@@ -60,6 +61,6 @@ float mix_master(float value, float off_value, float min_value, float max_value)
 #define PARAM_PHOSPHOR_AMOUNT mix_master(param.PHOSPHOR_AMOUNT, 0.0, 0.0, 1.0)
 #define PARAM_PHOSPHOR_DECAY param.PHOSPHOR_DECAY
 
-#define PARAM_HALATION_INTENSITY mix_master(param.HALATION_INTENSITY, 0.0, 0.0, 1.0)
-#define PARAM_HALATION_DIFFUSION param.HALATION_DIFFUSION
-#define PARAM_HALATION_INFLUENCE param.HALATION_INFLUENCE
+#define PARAM_HALATION_INTENSITY mix_master(global.HALATION_INTENSITY, 0.0, 0.0, 1.0)
+#define PARAM_HALATION_DIFFUSION global.HALATION_DIFFUSION
+#define PARAM_HALATION_INFLUENCE global.HALATION_INFLUENCE


### PR DESCRIPTION
This PR refines some aspects of the automatic screen scaling and adds a new options for mask pub-pixel order.

* Added Mask > Sub-Pixel Order parameter to switch between RGB and BGR order.
* Renamed Screen > Scale parameter to Scanlines > Scale, as this is what it mainly does. (implicit mask scaling has been removed)
* Changed Native option of Screen > Resolution parameter to not scale the mask when internal resolution changes dynamically (only scanlines adapt to the internal resolution)