### PR TITLE
add retro Mega Blocks effects (dome & brick versions)

### DIFF
--- a/handheld/mega-blocks-brick.slangp
+++ b/handheld/mega-blocks-brick.slangp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/mega-blocks-brick.slang
+scale_type0 = viewport
+filter_linear0 = false

--- a/handheld/mega-blocks-dome.slangp
+++ b/handheld/mega-blocks-dome.slangp
@@ -1,0 +1,5 @@
+shaders = 1
+
+shader0 = shaders/mega-blocks-dome.slang
+scale_type0 = viewport
+filter_linear0 = false

--- a/handheld/shaders/mega-blocks-brick.slang
+++ b/handheld/shaders/mega-blocks-brick.slang
@@ -1,0 +1,103 @@
+#version 450
+
+/* ================================================================
+ *  Mega Blocks Brick Shader
+ *  Superimposes lighting profiles onto source pixels to simulate 3D bricks.
+ *  Enforces per-axis integer scaling at vertex stage to eliminate moire.
+ *  Copyright (c) 2026 by crashGG.
+ * ================================================================ */
+
+layout(push_constant) uniform Push
+{
+    vec4  SourceSize;
+    vec4  OriginalSize;
+    vec4  OutputSize;
+    uint  FrameCount;
+    float bevel_depth;     
+    float highlight_ratio; 
+} params;
+
+// Bevel Depth: Default 0.27 | Range [0.01, 0.50] | Step 0.01
+#pragma parameter bevel_depth "Bevel Depth" 0.27 0.01 0.50 0.01
+#define bevel_depth params.bevel_depth
+
+// Highlight Ratio: Default 0.90 | Range [0.30, 1.25] | Step 0.05
+#pragma parameter highlight_ratio "Highlight Intensity" 0.90 0.30 1.25 0.05
+#define highlight_ratio params.highlight_ratio
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+/* ================================================================
+ *  Vertex Stage - Per-Axis Integer Scaling & Viewport Letterboxing
+ * ================================================================ */
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+layout(location = 1) out vec2 vScale;
+
+void main()
+{
+    vec4 clip = global.MVP * Position;
+
+    // Floor scaling factors independently per axis (clamped to 1.0 minimum)
+    vec2 int_scale = max(floor(params.OutputSize.xy * params.SourceSize.zw), vec2(1.0));
+
+    // Calculate the ratio of the integer-scaled frame relative to the target viewport
+    vec2 render_ratio = params.SourceSize.xy * (int_scale * params.OutputSize.zw);
+
+    clip.xy *= render_ratio;
+
+    gl_Position = clip;
+    vTexCoord   = TexCoord;
+    vScale      = int_scale;
+}
+
+/* ================================================================
+ *  Fragment Stage - Analytical Bevel Profile & Diagonal Lighting
+ * ================================================================ */
+#pragma stage fragment
+layout(location = 0) in  vec2 vTexCoord;
+layout(location = 1) in  vec2 vScale;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+// Mid-point intensity horizon along the unit square diagonal: |(0.5, 0.5)| = sqrt(0.5)
+const float ARC_ZERO = 0.70710678;
+
+void main()
+{
+    vec2 inv_scale = 1.0 / vScale;
+
+    // Normalized continuous coordinates within the current source pixel quad [0, 1)
+    vec2 cell_uv = fract(vTexCoord * params.SourceSize.xy);
+
+    vec3 color = texture(Source, vTexCoord).rgb;
+
+    // --- Compute Per-Axis Bevel Width in UV Space ---
+    vec2 bevel_w = max(round(vScale * 0.145898), vec2(1.0)) * inv_scale;
+
+    // --- Generate Bevel Mask ---
+    vec2  slope   = clamp(min(cell_uv, 1.0 - cell_uv) / bevel_w, 0.0, 1.0);
+    float is_edge = 1.0 - min(slope.x, slope.y);
+
+    // --- Diagonal Directional Lighting (2D Continuous Gradient) ---
+    float grad = -dot(cell_uv - 0.5, vec2(ARC_ZERO)) * 2.0;
+
+    float highlight = max(grad, 0.0) * highlight_ratio;
+    float shadow    = min(grad, 0.0);
+
+    // --- Screen-Space Edge Bleed Protection ---
+    // Smoothly attenuate shadows within the outermost source pixels to prevent harsh clipping boundaries
+    vec2  screen_d  = min(vTexCoord, 1.0 - vTexCoord);
+    float src_pixel = min(params.SourceSize.z, params.SourceSize.w);
+    shadow *= smoothstep(0.0, src_pixel, min(screen_d.x, screen_d.y));
+
+    // --- Final Compositing ---
+    vec3 weight = color * (highlight + shadow) * is_edge * bevel_depth;
+
+    FragColor = vec4(clamp(color + weight, 0.0, 1.0), 1.0);
+}

--- a/handheld/shaders/mega-blocks-dome.slang
+++ b/handheld/shaders/mega-blocks-dome.slang
@@ -1,0 +1,98 @@
+#version 450
+
+/* ================================================================
+ *  Mega Blocks Dome Shader
+ *  Superimposes circular lighting profiles onto source pixels to simulate 3D studs.
+ *  Enforces per-axis integer scaling at vertex stage to eliminate moire.
+ *  Copyright (c) 2026 by crashGG.
+ * ================================================================ */
+
+layout(push_constant) uniform Push
+{
+    vec4  SourceSize;
+    vec4  OriginalSize;
+    vec4  OutputSize;
+    uint  FrameCount;
+    float bevel_depth;
+    float highlight_ratio;
+} params;
+
+// Bevel Depth: Default 0.27 | Range [0.01, 0.50] | Step 0.01
+#pragma parameter bevel_depth "Bevel Depth" 0.27 0.01 0.50 0.01
+#define bevel_depth params.bevel_depth
+
+// Highlight Ratio: Default 0.90 | Range [0.30, 1.25] | Step 0.05
+#pragma parameter highlight_ratio "Highlight Intensity" 0.90 0.30 1.25 0.05
+#define highlight_ratio params.highlight_ratio
+
+layout(std140, set = 0, binding = 0) uniform UBO
+{
+    mat4 MVP;
+} global;
+
+/* ================================================================
+ *  Vertex Stage - Per-Axis Integer Scaling & Viewport Letterboxing
+ * ================================================================ */
+#pragma stage vertex
+layout(location = 0) in vec4 Position;
+layout(location = 1) in vec2 TexCoord;
+layout(location = 0) out vec2 vTexCoord;
+layout(location = 1) out vec2 vScale;
+
+void main()
+{
+    vec4 clip = global.MVP * Position;
+
+    // Floor scaling factors independently per axis (clamped to 1.0 minimum)
+    vec2 int_scale = max(floor(params.OutputSize.xy * params.SourceSize.zw), vec2(1.0));
+
+    // Calculate the ratio of the integer-scaled frame relative to the target viewport
+    vec2 render_ratio = params.SourceSize.xy * (int_scale * params.OutputSize.zw);
+
+    clip.xy *= render_ratio;
+
+    gl_Position = clip;
+    vTexCoord   = TexCoord;
+    vScale      = int_scale;
+}
+
+/* ================================================================
+ *  Fragment Stage - Radial Distance Field Lighting
+ * ================================================================ */
+#pragma stage fragment
+layout(location = 0) in  vec2 vTexCoord;
+layout(location = 1) in  vec2 vScale;
+layout(location = 0) out vec4 FragColor;
+layout(set = 0, binding = 2) uniform sampler2D Source;
+
+// Mid-point intensity horizon along the unit square diagonal: |(0.5, 0.5)| = sqrt(0.5)
+const float ARC_ZERO = 0.70710678;
+
+void main()
+{
+    // Normalized continuous coordinates within the current source pixel quad [0, 1)
+    vec2 cell_uv = fract(vTexCoord * params.SourceSize.xy);
+
+    // Floating-point precision jitter protection at integer boundaries
+    cell_uv = mix(cell_uv, vec2(0.0), step(vec2(0.9999), cell_uv));
+
+    // --- Coordinate Quantization ---
+    // Quantizes pixel centers to discrete integer indices normalized over the [0, 1] range.
+    // This anchors the minimum/maximum lighting intensities perfectly at the cell corners.
+    vec2 position = floor(cell_uv * vScale)
+                  / max(vScale - vec2(1.0), vec2(1.0));
+
+    // --- Radial Distance Field ---
+    // Evaluates Euclidean distance to the top-left corner (0,0) to form a circular shading profile.
+    float shading_field = ARC_ZERO - length(position);
+
+    // --- Asymmetric Shading Profile ---
+    float shade = min(shading_field, 0.0)
+               + max(shading_field, 0.0) * highlight_ratio;
+
+    // --- Final Compositing ---
+    vec3 color  = texture(Source, vTexCoord).rgb;
+    vec3 result = color + color * shade * bevel_depth;
+
+    FragColor = vec4(clamp(result, 0.0, 1.0), 1.0);
+}


### PR DESCRIPTION
1. `mega-blocks-dome`: Generates rounded dome highlights and asymmetric radial shadows on every source texel.
2. `mega-blocks-brick`: Generates isometric square beveled framing with an L2 projection lighting direction.

Requires integer scaling to prevent moiré patterns.
Specially designed to render low-resolution handheld content (like GB 144p，GBA 160p) beautifully on large-screen 4K displays.

**mega-blocks-dome**：

<img width="2400" height="2160" alt="超级马力欧乐园 DX  中文 -260728-180852" src="https://github.com/user-attachments/assets/4531ec04-3997-4b6c-94b3-53912003ba84" />

<img width="264" height="293" alt="超级马力欧乐园 DX  中文 -260728-180852_cr" src="https://github.com/user-attachments/assets/fe0afc68-22e4-4ae2-99a0-f031a7ae517f" />


**mega-blocks-brick**：

<img width="2400" height="2160" alt="超级马力欧乐园 DX  中文 -260728-180844" src="https://github.com/user-attachments/assets/c661973f-50bf-4c2e-96dd-66294b319f38" />

<img width="264" height="293" alt="超级马力欧乐园 DX  中文 -260728-180844_cr" src="https://github.com/user-attachments/assets/1fd374cb-c4bd-4b3c-b8d7-4181d463df0e" />
