### PR TITLE
add Anti-Flicker Extended

### DIFF
--- a/misc/shaders/anti-flicker.slang
+++ b/misc/shaders/anti-flicker.slang
@@ -1,29 +1,47 @@
 #version 450
 
 /*
-	Anti-Flicker shader
-	by hunterk
-	License: public domain
+	Anti-Flicker Shader
+	Original by hunterk
+	License: Public Domain
 	
 	This shader detects large variations in luminance from frame to frame
 	and then blends frames to smooth the transition. In flicker-based
 	shadow effects, this should result in true transparency.
+
+	====================================================================
+	Extended & Optimized by crashGG
+	
+	Key enhancements:
+	- Expanded the frame history to build a more stable temporal detection chain.
+	- Added an alternating frame color-lock to prevent false positives and tracking errors.
+	- Swapped to BT.601 luma weights to properly match 16bit and CRT-era specifications.
+	- Implemented a fast gamma approximation to replace expensive pow() calls.
+	- Added an adjustable Flicker detection window to skip processing outside range.
 */
 
 layout(push_constant) uniform Push
 {
-	vec4 SourceSize;
-	vec4 OriginalSize;
-	vec4 OutputSize;
-	uint FrameCount;
-	float THRESH;
+    vec4 SourceSize;
+    vec4 OriginalSize;
+    vec4 OutputSize;
+    uint FrameCount;
+    float thresh;
+    float startRow;
+    float endRow;
 } params;
 
-#pragma parameter THRESH "Luma Diff Threshold" 0.25 0.0 1.0 0.05
+#pragma parameter thresh "Luma Diff Threshold" 0.20 0.0 1.0 0.01
+#pragma parameter startRow "Flicker detection start row (%)" 0.00 0.0 1.0 0.01
+#pragma parameter endRow   "Flicker detection end row (%)" 1.00 0.0 1.0 0.01
+
+#define thresh params.thresh
+#define startRow params.startRow
+#define endRow params.endRow
 
 layout(std140, set = 0, binding = 0) uniform UBO
 {
-	mat4 MVP;
+    mat4 MVP;
 } global;
 
 #pragma stage vertex
@@ -33,44 +51,58 @@ layout(location = 0) out vec2 vTexCoord;
 
 void main()
 {
-   gl_Position = global.MVP * Position;
-   vTexCoord = TexCoord;
+    gl_Position = global.MVP * Position;
+    vTexCoord = TexCoord;
 }
 
 #pragma stage fragment
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 FragColor;
-layout(set = 0, binding = 2) uniform sampler2D Source;
+layout(set = 0, binding = 2) uniform sampler2D Original;
 layout(set = 0, binding = 3) uniform sampler2D OriginalHistory1;
 layout(set = 0, binding = 4) uniform sampler2D OriginalHistory2;
 layout(set = 0, binding = 5) uniform sampler2D OriginalHistory3;
+layout(set = 0, binding = 6) uniform sampler2D OriginalHistory4;
+layout(set = 0, binding = 7) uniform sampler2D OriginalHistory5;
 
 void main()
 {
-	// sample the textures
-	vec4 current = texture(Source, vTexCoord);
-	vec4 prev1 = texture(OriginalHistory1, vTexCoord);
-	vec4 prev2 = texture(OriginalHistory2, vTexCoord);
-	vec4 prev3 = texture(OriginalHistory3, vTexCoord);
-	
-	// get luma for comparison
-	float cur_lum = dot(current.rgb, vec3(0.2125, 0.7154, 0.0721));
-	float prev1_lum = dot(prev1.rgb, vec3(0.2125, 0.7154, 0.0721));
-	float prev2_lum = dot(prev2.rgb, vec3(0.2125, 0.7154, 0.0721));
-	float prev3_lum = dot(prev3.rgb, vec3(0.2125, 0.7154, 0.0721));
-	
-	// Test whether the luma difference between the pixel in the current frame and that of
-	// the previous frame exceeds the threshold while the difference between the current frame
-	// and 2 frames previous is below the threshold.
-	// Repeat the process for the previous frame's pixel to reduce false-positives
-	bool flicker = (abs(cur_lum - prev1_lum) > params.THRESH && abs(cur_lum - prev2_lum) < params.THRESH) &&
-		(abs(prev1_lum - prev2_lum) > params.THRESH && abs(prev1_lum - prev3_lum) < params.THRESH);
-	
-	// Average the current frame with the previous frame in linear color space to avoid over-darkening
-	vec4 blended = (pow(current, vec4(2.2)) + pow(prev1, vec4(2.2))) / 2.0;
-	
-	// delinearize the averaged result
-	blended = pow(blended, vec4(1.0 / 2.2));
-	
-	FragColor = (!flicker) ? current : blended;
+
+    vec3 curr0 = texture(Original, vTexCoord).rgb;
+    vec3 prev1 = texture(OriginalHistory1, vTexCoord).rgb;
+    vec3 prev2 = texture(OriginalHistory2, vTexCoord).rgb;
+    vec3 prev3 = texture(OriginalHistory3, vTexCoord).rgb;
+    vec3 prev4 = texture(OriginalHistory4, vTexCoord).rgb;
+    vec3 prev5 = texture(OriginalHistory5, vTexCoord).rgb;
+
+    // Bounds check: active only within [startRow, endRow] Y-range
+    float isInRegion = step(startRow, vTexCoord.y) * step(vTexCoord.y, endRow);
+    
+    // BT.601 luma weights
+    vec3 luma_weight = vec3(0.299, 0.587, 0.114);
+    float curr0Luma = dot(curr0, luma_weight);
+    float prev1Luma = dot(prev1, luma_weight);
+    float prev2Luma = dot(prev2, luma_weight);
+    float prev3Luma = dot(prev3, luma_weight);
+    float prev4Luma = dot(prev4, luma_weight);
+    float prev5Luma = dot(prev5, luma_weight);
+    
+    // Interlaced frame lock: even/odd 3-frame sequences must match
+    bool chain024 = abs(curr0Luma - prev2Luma) < 0.01 && abs(prev2Luma - prev4Luma) < 0.01;
+    bool chain135 = abs(prev1Luma - prev3Luma) < 0.01 && abs(prev3Luma - prev5Luma) < 0.01;
+
+    bool flicker = bool(isInRegion)
+                && (chain024 || chain135)
+                && (abs(curr0Luma - prev1Luma) > thresh)
+                && (abs(prev2Luma - prev3Luma) > thresh)
+                && (abs(prev4Luma - prev5Luma) > thresh);
+				   
+    // Fast gamma approximation to avoid expensive pow(x, 2.2) and pow(x, 1.0/2.2)
+    // Precision loss: < 1% ; ALU cost: ~10x cheaper
+    vec3 blendedRgb = mix(curr0 * curr0, prev1 * prev1, 0.5);
+    blendedRgb = sqrt(blendedRgb);
+    
+    vec3 finalRgb = flicker ? blendedRgb : curr0;
+    
+    FragColor = vec4(finalRgb, 1.0);
 }


### PR DESCRIPTION
a mod of hunterk's Anti-Flicker shader, aiming to fix artifacts and improve accuracy during camera/character movement.

Key enhancements:
Expanded the frame history to build a more stable temporal detection chain.
Added an alternating frame color-lock to prevent false positives and tracking errors.
it greatly fix artifacts while character is moving.
Swapped to BT.601 luma weights to properly match 16bit and CRT-era specifications.
Implemented a fast gamma approximation to replace expensive pow() calls.
precision loss: < 1%, ALU cost: ~10x cheaper
Added an adjustable Flicker detection window to skip processing outside range.
<img width="720" height="504" alt="powerinsb-260807-233757" src="https://github.com/user-attachments/assets/63bff160-a08e-4187-93ac-e9aca7a69b37" />
Precisely lock onto flickering shadow areas in specific games, while maintaining the clean RAW output outside the area.